### PR TITLE
Add support for passing options to the htmlbars precompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,32 @@ var HTMLBarsInlinePrecompile = require('babel-plugin-htmlbars-inline-precompile'
 var pluginConfiguredWithCompiler = HTMLBarsInlinePrecompile(HTMLBarsCompiler.precompile);
 
 require('babel').transform("code", {
-  plugins: [ pluginConfiguredWithCompiler ]
+  plugins: [ pluginConfiguredWithCompiler]
+});
+```
+
+### Passing options to the precompiler
+
+As of 0.0.6, there is now the ability to pass options to the HTMLBars precompiler.
+
+This enables passing `moduleName`, which can be used to retrieve from within the compiled template where it originated from.
+
+``` js
+var HTMLBarsCompiler = require('./bower_components/ember/ember-template-compiler');
+var HTMLBarsInlinePrecompile = require('babel-plugin-htmlbars-inline-precompile');
+
+var pluginConfiguredWithCompiler = HTMLBarsInlinePrecompile(HTMLBarsCompiler.precompile, {
+  precompileOptions: function(opts) {
+    // example of moduleName generation
+    var sourceRootRegEx = new RegExp("^" + opts.sourceRoot + "/?");
+
+    return {
+      moduleName: opts.filenameRelative.replace(sourceRootRegEx, "")
+    };
+  }
+});
+
+require('babel').transform("code", {
+  plugins: [ pluginConfiguredWithCompiler]
 });
 ```

--- a/index.js
+++ b/index.js
@@ -4,10 +4,13 @@ module.exports = function(precompile) {
 
     var replaceNodeWithPrecompiledTemplate = function(node, template, file) {
       var moduleName = file.opts && file.opts.filenameRelative;
+      var opts = {};
 
-      var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template, {
-        moduleName: moduleName
-      }) + ")";
+      if (moduleName && moduleName !== 'unknown') {
+        opts.moduleName = moduleName;
+      }
+
+      var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template, opts) + ")";
 
       // Prefer calling replaceWithSourceString if it is present.
       // this prevents a deprecation warning in Babel 5.6.7+.

--- a/index.js
+++ b/index.js
@@ -2,8 +2,12 @@ module.exports = function(precompile) {
   return function(babel) {
     var t = babel.types;
 
-    var replaceNodeWithPrecompiledTemplate = function(node, template) {
-      var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template) + ")";
+    var replaceNodeWithPrecompiledTemplate = function(node, template, file) {
+      var moduleName = file.opts && file.opts.filenameRelative;
+
+      var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template, {
+        moduleName: moduleName
+      }) + ")";
 
       // Prefer calling replaceWithSourceString if it is present.
       // this prevents a deprecation warning in Babel 5.6.7+.
@@ -54,7 +58,7 @@ module.exports = function(precompile) {
             throw file.errorWithNode(node, argumentErrorMsg);
           }
 
-          return replaceNodeWithPrecompiledTemplate(this, template);
+          return replaceNodeWithPrecompiledTemplate(this, template, file);
         }
       },
 
@@ -68,7 +72,7 @@ module.exports = function(precompile) {
             return quasi.value.cooked;
           }).join("");
 
-          return replaceNodeWithPrecompiledTemplate(this, template);
+          return replaceNodeWithPrecompiledTemplate(this, template, file);
         }
       }
     });

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
-module.exports = function(precompile) {
+module.exports = function(precompile, pluginOptions) {
   return function(babel) {
     var t = babel.types;
 
     var replaceNodeWithPrecompiledTemplate = function(node, template, file) {
-      var moduleName = file.opts && file.opts.filenameRelative;
       var opts = {};
 
-      if (moduleName && moduleName !== 'unknown') {
-        opts.moduleName = moduleName;
+      if (pluginOptions && typeof pluginOptions.precompileOptions === 'function') {
+        var ret = pluginOptions.precompileOptions(file.opts);
+        if (typeof ret === 'object') {
+          opts = ret;
+        }
       }
 
       var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template, opts) + ")";

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.5",
   "description": "Babel plugin to replace tagged template strings with precompiled HTMLBars templates",
   "scripts": {
-    "test": "mocha tests"
+    "test": "mocha tests",
+    "test:watch": "mocha -w tests"
   },
   "repository": "https://github.com/pangratz/babel-plugin-htmlbars-inline-precompile",
   "author": "Clemens Müller <cmueller.418@gmail.com>",

--- a/tests/fixtures/hello-world.js
+++ b/tests/fixtures/hello-world.js
@@ -1,0 +1,3 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export default hbs('hello');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -68,6 +68,22 @@ describe("htmlbars-inline-precompile", function() {
       assert.equal(transformed, "var compiled = Ember.HTMLBars.template(precompiled(hello));", "tagged template is replaced");
     });
 
+    it("moduleName (filenameRelative) is passed through to precompiler", function() {
+      var code = "import hbs from 'htmlbars-inline-precompile'; var compiled = hbs('hello');";
+
+      var precompile = function(template, options) {
+        assert.equal(options.moduleName, 'module-name-test.js');
+
+        return "precompiled(" + template + ")";
+      };
+
+      babel.transform(code, {
+        blacklist: ['strict', 'es6.modules'],
+        plugins: [HTMLBarsInlinePrecompile(precompile)],
+        filenameRelative: 'module-name-test.js'
+      });
+    });
+
     it("warns when more than one argument is passed", function() {
       assert.throws(function() {
         transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs('first', 'second');");

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -59,18 +59,30 @@ describe("htmlbars-inline-precompile", function() {
     }, /placeholders inside a tagged template string are not supported/);
   });
 
-  it("moduleName is supplies to the precompiler", function() {
-    var fullpath = path.join(__dirname, 'fixtures', 'hello-world.js');
+  it("precompileOptions can return options to the precompiler", function() {
+    var sourceRoot = path.join(__dirname, 'fixtures');
+    var filename = 'hello-world.js';
+    var fullpath = path.join(sourceRoot, filename);
 
     var precompile = function(template, options) {
-      assert.equal(options.moduleName, fullpath);
+      assert.equal(options.moduleName, filename);
 
       return "precompiled(" + template + ")";
     };
 
-    babel.transformFileSync(fullpath, {
+    var transpiled = babel.transformFileSync(fullpath, {
       blacklist: ['strict', 'es6.modules'],
-      plugins: [HTMLBarsInlinePrecompile(precompile)]
+      sourceRoot: sourceRoot,
+      plugins: [HTMLBarsInlinePrecompile(precompile, {
+        precompileOptions: function(opts) {
+          // example of how someone might use it to construct their own moduleName
+          var sourceRootRegEx = new RegExp("^" + opts.sourceRoot + "/?");
+
+          return {
+            moduleName: opts.filenameRelative.replace(sourceRootRegEx, "")
+          };
+        }
+      })]
     });
   });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,5 +1,5 @@
+var path = require('path');
 var assert = require('assert');
-
 var babel = require('babel-core');
 var HTMLBarsInlinePrecompile = require('../index');
 
@@ -59,6 +59,21 @@ describe("htmlbars-inline-precompile", function() {
     }, /placeholders inside a tagged template string are not supported/);
   });
 
+  it("moduleName is supplies to the precompiler", function() {
+    var fullpath = path.join(__dirname, 'fixtures', 'hello-world.js');
+
+    var precompile = function(template, options) {
+      assert.equal(options.moduleName, fullpath);
+
+      return "precompiled(" + template + ")";
+    };
+
+    babel.transformFileSync(fullpath, {
+      blacklist: ['strict', 'es6.modules'],
+      plugins: [HTMLBarsInlinePrecompile(precompile)]
+    });
+  });
+
   describe('single string argument', function() {
     it("works with a plain string as parameter hbs('string')", function() {
       var transformed = transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs('hello');", function(template) {
@@ -66,22 +81,6 @@ describe("htmlbars-inline-precompile", function() {
       });
 
       assert.equal(transformed, "var compiled = Ember.HTMLBars.template(precompiled(hello));", "tagged template is replaced");
-    });
-
-    it("moduleName (filenameRelative) is passed through to precompiler", function() {
-      var code = "import hbs from 'htmlbars-inline-precompile'; var compiled = hbs('hello');";
-
-      var precompile = function(template, options) {
-        assert.equal(options.moduleName, 'module-name-test.js');
-
-        return "precompiled(" + template + ")";
-      };
-
-      babel.transform(code, {
-        blacklist: ['strict', 'es6.modules'],
-        plugins: [HTMLBarsInlinePrecompile(precompile)],
-        filenameRelative: 'module-name-test.js'
-      });
     });
 
     it("warns when more than one argument is passed", function() {


### PR DESCRIPTION
`ember-cli-htmlbars` also sets `moduleName` and other transformations may rely on this property.

https://github.com/ember-cli/ember-cli-htmlbars/blob/master/index.js#L69

This PR brings the ability to implement a method to construct a `moduleName` based on the babel options that the babel transform provides to plugins.  It will also work with any future options that may be added to the precompiler.
