### PR TITLE
Incorporate cache keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ test("inline templates ftw", function(assert) {
 var HTMLBarsCompiler = require('./bower_components/ember/ember-template-compiler');
 var HTMLBarsInlinePrecompile = require('babel-plugin-htmlbars-inline-precompile');
 
-var pluginConfiguredWithCompiler = HTMLBarsInlinePrecompile(HTMLBarsCompiler.precompile);
+var pluginConfiguredWithCompiler = HTMLBarsInlinePrecompile(HTMLBarsCompiler.precompile, {
+  cacheKey: checksumOfTemplateCompilerContents
+});
 
 require('babel').transform("code", {
   plugins: [ pluginConfiguredWithCompiler ]
 });
 ```
+
+The provided `cacheKey` option is used to invalidate the broccoli-babel-transpiler cache.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-module.exports = function(precompile) {
-  return function(babel) {
+module.exports = function(precompile, _options) {
+  var options = _options || {};
+
+  function htmlbarsInlineCompilerPlugin(babel) {
     var t = babel.types;
 
     var replaceNodeWithPrecompiledTemplate = function(node, template) {
@@ -73,4 +75,20 @@ module.exports = function(precompile) {
       }
     });
   }
+
+  // used by broccoli-babel-transpiler to use this packages
+  // files and deps as part of the cache key (when deps or
+  // implementation changes it will bust the cache for already
+  // transpiled files)
+  htmlbarsInlineCompilerPlugin.baseDir = function() {
+    return __dirname;
+  };
+
+  // used by broccoli-babel-transpiler to bust the cache when
+  // the template compiler being used changes
+  htmlbarsInlineCompilerPlugin.cacheKey = function() {
+    return options.cacheKey;
+  };
+
+  return htmlbarsInlineCompilerPlugin;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-htmlbars-inline-precompile",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Babel plugin to replace tagged template strings with precompiled HTMLBars templates",
   "scripts": {
     "test": "mocha tests"

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var path = require('path');
 
 var babel = require('babel-core');
 var HTMLBarsInlinePrecompile = require('../index');
@@ -57,6 +58,20 @@ describe("htmlbars-inline-precompile", function() {
     assert.throws(function() {
       transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs`string ${value}`");
     }, /placeholders inside a tagged template string are not supported/);
+  });
+
+  describe('caching', function() {
+    it('passes through second argument as `cacheKey`', function() {
+      var plugin = HTMLBarsInlinePrecompile(function() {}, { cacheKey: 'asdfasdf' });
+
+      assert.equal(plugin.cacheKey(), 'asdfasdf');
+    });
+
+    it('include `baseDir` function for caching', function() {
+      var plugin = HTMLBarsInlinePrecompile(function() {}, 'asdfasdf');
+
+      assert.equal(plugin.baseDir(), path.resolve(__dirname, '..'));
+    });
   });
 
   describe('single string argument', function() {


### PR DESCRIPTION
Provide `baseDir` and pass through second argument as `cacheKey`.

This is backwards compat to 0.0.5...