### PR TITLE
CI: Enable automatic NPM deployment for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,12 @@ install:
 
 script:
   - npm test
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: R4p+j6Db+sLQfang4Afg50OPjt5H33r79GRXxvtKHQMWETAE88/NJaEnldQyLPNRhg/lZTPLDbd2dCF1P/fFgK73o0eqF1Zdv1q2GUuINDcb/cxCQDqdQCd/YGA27seKsKWuKWgE4t9jMXwAX72S279U+zn1jrC1kWk1q9lx7lI=
+  on:
+    tags: true
+    repo: ember-cli/babel-plugin-htmlbars-inline-precompile


### PR DESCRIPTION
After merging this you no longer have to `npm publish` manually. TravisCI will test all pushed tags and deploy automatically after all tests passed.

`git owner add ember-cli` is still needed, because I didn't have the NPM owner bit to do it myself.

/cc @nathanhammond @stefanpenner @rwjblue @pangratz 