### PR TITLE
Refactor to work when before babel-plugin-transform-es2015-template-literals.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.7.4",
+    "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "mocha": "^3.0.2"
   }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 const babel = require('babel-core');
 const HTMLBarsInlinePrecompile = require('../index');
+const TransformTemplateLiterals = require('babel-plugin-transform-es2015-template-literals');
 
 describe("htmlbars-inline-precompile", function() {
   let precompile, plugins;
@@ -44,13 +45,19 @@ describe("htmlbars-inline-precompile", function() {
     }
   });
 
-
   it("replaces tagged template expressions with precompiled version", function() {
     precompile = template => `precompiled(${template})`;
 
     let transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;");
 
     assert.equal(transformed, "var compiled = Ember.HTMLBars.template(precompiled(hello));", "tagged template is replaced");
+  });
+
+  it("replaces tagged template expressions when before babel-plugin-transform-es2015-template-literals", function() {
+    plugins.push([TransformTemplateLiterals]);
+    let transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;");
+
+    assert.equal(transformed, "var compiled = Ember.HTMLBars.template(HELLO);", "tagged template is replaced");
   });
 
   it("doesn't replace unrelated tagged template strings", function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,6 +68,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-es2015-template-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-register@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.23.0.tgz#c9aa3d4cca94b51da34826c4a0f9e08145d74ff3"


### PR DESCRIPTION
Prior to this change, when `babel-plugin-transform-es2015-template-literals` was present in the `plugins` array its `TaggedTemplateExpression` visitor was always ran prior to this plugins `Identifier` plugin (because the `TaggedTemplateExpression` is "seen" before the `Identifier`).

Since the `babel-plugin-transform-es2015-template-literals` plugin then transforms the tagged template literal into a custom transpiled version (for use in runtime) the `babel-plugin-htmlbars-inline-precompile` plugin never functioned properly.

The refactor also seems to simplify (IMO) and make this a bit easier to reason about.

---

It may be easier to review this as independent commits (the first 3 are just setting up our testing mechanisms).