### PR TITLE
Allow `modulePaths` configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,16 @@ module.exports = function(babel) {
     visitor: {
       ImportDeclaration: function(path, state) {
         let node = path.node;
-        if (t.isLiteral(node.source, { value: "htmlbars-inline-precompile" })) {
+
+        let modulePaths = state.opts.modulePaths || ["htmlbars-inline-precompile"];
+        let matchingModulePath = modulePaths.find(value => t.isLiteral(node.source, { value }));
+
+        if (matchingModulePath) {
           let first = node.specifiers && node.specifiers[0];
           if (!t.isImportDefaultSpecifier(first)) {
             let input = state.file.code;
             let usedImportStatement = input.slice(node.start, node.end);
-            let msg = `Only \`import hbs from 'htmlbars-inline-precompile'\` is supported. You used: \`${usedImportStatement}\``;
+            let msg = `Only \`import hbs from '${matchingModulePath}'\` is supported. You used: \`${usedImportStatement}\``;
             throw path.buildCodeFrameError(msg);
           }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -46,6 +46,14 @@ describe("htmlbars-inline-precompile", function() {
     expect(transformed).toEqual("var compiled = Ember.HTMLBars.template(precompiled(hello));", "tagged template is replaced");
   });
 
+  it("replaces tagged template expressions with precompiled version for custom import paths", function() {
+    plugins[0][1].modulePaths = ['ember-cli-htmlbars-inline-precompile'];
+
+    let transformed = transform("import hbs from 'ember-cli-htmlbars-inline-precompile';\nvar compiled = hbs`hello`;");
+
+    expect(transformed).toEqual("var compiled = Ember.HTMLBars.template(precompiled(hello));");
+  });
+
   it("does not cause an error when no import is found", function() {
     expect(() => transform('something("whatever")')).not.toThrow();
     expect(() => transform('something`whatever`')).not.toThrow();


### PR DESCRIPTION
This addresses https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/issues/101 by making the actual module import paths configurable.