### PR TITLE
Allowing you to test templates from MU co-located tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const parseModuleName = require('./lib/parse-module-name');
+
 module.exports = function(babel) {
   let t = babel.types;
 
@@ -39,7 +41,16 @@ module.exports = function(babel) {
         }
 
         let template = path.node.quasi.quasis.map(quasi => quasi.value.cooked).join('');
-        let compiledTemplateString = `Ember.HTMLBars.template(${state.opts.precompile(template)})`;
+
+        let options = {
+          meta: {}
+        }
+
+        if (state.file.opts.filename.includes('-components')) {
+          options.meta.moduleName = parseModuleName(state.file.opts.filename);
+        }
+
+        let compiledTemplateString = `Ember.HTMLBars.template(${state.opts.precompile(template, options)})`;
 
         path.replaceWithSourceString(compiledTemplateString);
       },

--- a/index.js
+++ b/index.js
@@ -46,8 +46,14 @@ module.exports = function(babel) {
           meta: {}
         }
 
-        if (state.file.opts.filename.includes('-components')) {
-          options.meta.moduleName = parseModuleName(state.file.opts.filename);
+        let filename = state.file.opts.filename;
+        let filenameParts = filename.split('/');
+        filenameParts.splice(0, 1);
+
+        if (filename.includes('-components')) {
+          options.meta.moduleName = parseModuleName(filename);
+        } else if (filenameParts[2] === 'components' && filenameParts.length > 5) {
+          options.meta.moduleName = parseModuleName(filename);
         }
 
         let compiledTemplateString = `Ember.HTMLBars.template(${state.opts.precompile(template, options)})`;

--- a/index.js
+++ b/index.js
@@ -47,13 +47,10 @@ module.exports = function(babel) {
         }
 
         let filename = state.file.opts.filename;
-        let filenameParts = filename.split('/');
-        filenameParts.splice(0, 1);
+        let moduleName = parseModuleName(filename);
 
-        if (filename.includes('-components')) {
-          options.meta.moduleName = parseModuleName(filename);
-        } else if (filenameParts[2] === 'components' && filenameParts.length > 5) {
-          options.meta.moduleName = parseModuleName(filename);
+        if (moduleName) {
+          options.meta.moduleName = moduleName;
         }
 
         let compiledTemplateString = `Ember.HTMLBars.template(${state.opts.precompile(template, options)})`;

--- a/lib/parse-module-name.js
+++ b/lib/parse-module-name.js
@@ -10,8 +10,10 @@ module.exports = function (filename) {
 
   if (componentsIndex > 0) {
     parts.splice(componentsIndex);
-  } else {
+  } else if (parts[2] === 'components' && parts.length > 5) {
     parts.splice(parts.length - 2);
+  } else {
+    return null
   }
 
   parts.push('template');

--- a/lib/parse-module-name.js
+++ b/lib/parse-module-name.js
@@ -8,7 +8,13 @@ module.exports = function (filename) {
 
   const componentsIndex = parts.indexOf('-components');
 
-  parts.splice(componentsIndex);
+  if (componentsIndex > 0) {
+    parts.splice(componentsIndex);
+  } else {
+    parts.splice(parts.length - 2);
+  }
+
+  parts.push('template');
 
   return parts.join('/') + '.hbs';
 }

--- a/lib/parse-module-name.js
+++ b/lib/parse-module-name.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = function (filename) {
+  const parts = filename.split('/');
+
+  // remove application name
+  parts.splice(0, 1);
+
+  const componentsIndex = parts.indexOf('-components');
+
+  parts.splice(componentsIndex);
+
+  return parts.join('/') + '.hbs';
+}

--- a/lib/parse-module-name.js
+++ b/lib/parse-module-name.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function (filename) {
-  let parts = filename.split('/');
+  let parts = filename.split(/[/\\]/);
 
   // Drop the application name from the parts
   parts.shift();

--- a/tests/parse-module-name.js
+++ b/tests/parse-module-name.js
@@ -4,7 +4,7 @@ const parseModuleName = require('../lib/parse-module-name');
 
 describe('parse-module-name helper', function() {
   it('should return applicaiton template when using a route local -component', function() {
-    expect(parseModuleName('emberconf/src/ui/routes/application/-components/footer-prompt/component-test.js')).toEqual('src/ui/routes/application.hbs');
+    expect(parseModuleName('emberconf/src/ui/routes/application/-components/footer-prompt/component-test.js')).toEqual('src/ui/routes/application/template.hbs');
   })
 
   it('should return the parent component when using a component local component', function() {

--- a/tests/parse-module-name.js
+++ b/tests/parse-module-name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const parseModuleName = require('../lib/parse-module-name');
+
+describe.only('parse-module-name helper', function() {
+  it('should return applicaiton template when using a route local -component', function() {
+    expect(parseModuleName('emberconf/src/ui/routes/application/-components/footer-prompt/component-test.js')).toEqual('src/ui/routes/application.hbs');
+  })
+})

--- a/tests/parse-module-name.js
+++ b/tests/parse-module-name.js
@@ -2,8 +2,12 @@
 
 const parseModuleName = require('../lib/parse-module-name');
 
-describe.only('parse-module-name helper', function() {
+describe('parse-module-name helper', function() {
   it('should return applicaiton template when using a route local -component', function() {
     expect(parseModuleName('emberconf/src/ui/routes/application/-components/footer-prompt/component-test.js')).toEqual('src/ui/routes/application.hbs');
+  })
+
+  it('should return the parent component when using a component local component', function() {
+    expect(parseModuleName('emberconf/src/ui/components/icon-emberconf/facey-face/component-test.js')).toEqual('src/ui/components/icon-emberconf/template.hbs');
   })
 })


### PR DESCRIPTION
This is a result of a pairing session with @iezer trying to get the integration tests on the emberconf2018 MU app to work: https://github.com/201-created/emberconf-schedule-2018/blob/integration-tests/src/ui/routes/application/-components/footer-prompt/component-test.js#L13

We have come up with 2 scenarios that it needs to work with:
- [x] components inside `-components` folders in routes
- [x] components inside other components' folders

This PR is reasonably hacky 😂 it's very much supposed to be a "here this works, how should we make it play nice" kind of implementation.