### PR TITLE
Pass through options to `precompile`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,16 @@
 module.exports = function(babel) {
   let t = babel.types;
 
+  function compileTemplate(precompile, template) {
+    let options = {
+      contents: template
+    }
+
+    let compiledTemplateString = `Ember.HTMLBars.template(${precompile(template, options)})`;
+
+    return compiledTemplateString;
+  }
+
   return {
     visitor: {
       ImportDeclaration: function(path, state) {
@@ -39,9 +49,8 @@ module.exports = function(babel) {
         }
 
         let template = path.node.quasi.quasis.map(quasi => quasi.value.cooked).join('');
-        let compiledTemplateString = `Ember.HTMLBars.template(${state.opts.precompile(template)})`;
 
-        path.replaceWithSourceString(compiledTemplateString);
+        path.replaceWithSourceString(compileTemplate(state.opts.precompile, template, state.file.opts.filename));
       },
 
       CallExpression(path, state) {
@@ -62,9 +71,7 @@ module.exports = function(babel) {
           throw path.buildCodeFrameError(argumentErrorMsg);
         }
 
-        let compiledTemplateString = `Ember.HTMLBars.template(${state.opts.precompile(template)})`;
-
-        path.replaceWithSourceString(compiledTemplateString);
+        path.replaceWithSourceString(compileTemplate(state.opts.precompile, template, state.file.opts.filename));
       },
     }
   };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -8,22 +8,43 @@ const TransformTemplateLiterals = require('babel-plugin-transform-es2015-templat
 const TransformModules = require('babel-plugin-transform-es2015-modules-amd');
 
 describe("htmlbars-inline-precompile", function() {
-  let plugins;
+  let plugins, optionsReceived;
 
   function transform(code) {
     return babel.transform(code, {
+      filename: 'foo-bar.js',
       plugins
     }).code.trim();
   }
 
   beforeEach(function() {
+    optionsReceived = undefined;
     plugins = [
       [HTMLBarsInlinePrecompile, {
-        precompile(template) {
+        precompile(template, options) {
+          optionsReceived = options;
           return `precompiled(${template})`;
         }
       }],
     ];
+  });
+
+  it('passes options when used as a call expression', function() {
+    let source = 'hello';
+    transform(`import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('${source}');`);
+
+    expect(optionsReceived).toEqual({
+      contents: source,
+    });
+  });
+
+  it('passes options when used as a tagged template string', function() {
+    let source = 'hello';
+    transform(`import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs\`${source}\`;`);
+
+    expect(optionsReceived).toEqual({
+      contents: source,
+    });
   });
 
   it("strips import statement for 'htmlbars-inline-precompile' module", function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,6 +808,13 @@ cosmiconfig@^3.0.1:
     parse-json "^3.0.0"
     require-from-string "^2.0.1"
 
+create-jest-runner@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/create-jest-runner/-/create-jest-runner-0.3.1.tgz#c4cd197a3fe3dcfff3f0e1b2c19f7cc562ac6928"
+  dependencies:
+    jest-worker "^22.0.0"
+    throat "^4.1.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -949,7 +956,7 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-errno@^0.1.4, errno@~0.1.7:
+errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
@@ -2046,16 +2053,14 @@ jest-resolve@^21.2.0:
     chalk "^2.0.1"
     is-builtin-module "^1.0.0"
 
-jest-runner-eslint@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/jest-runner-eslint/-/jest-runner-eslint-0.4.0.tgz#938a54fb767d1803d45613ae3eac0adc2de426db"
+jest-runner-eslint@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/jest-runner-eslint/-/jest-runner-eslint-0.6.0.tgz#cd2fbe204c4cde7a8783496c1ea0ac17bc5d0002"
   dependencies:
     cosmiconfig "^3.0.1"
+    create-jest-runner "^0.3.0"
     eslint "^4.5.0"
     find-up "^2.1.0"
-    pify "3.0.0"
-    throat "4.1.0"
-    worker-farm "1.5.0"
 
 jest-runner@^21.2.1:
   version "21.2.1"
@@ -2125,6 +2130,12 @@ jest-validate@^21.2.1:
     jest-get-type "^21.2.0"
     leven "^2.1.0"
     pretty-format "^21.2.1"
+
+jest-worker@^22.0.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
+  dependencies:
+    merge-stream "^1.0.1"
 
 jest@^21.0.0:
   version "21.2.1"
@@ -2331,6 +2342,12 @@ mem@^1.1.0:
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
+
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  dependencies:
+    readable-stream "^2.0.1"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -2723,13 +2740,13 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@3.0.0, pify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -2845,6 +2862,18 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
+
+readable-stream@^2.0.1:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.5"
@@ -3277,6 +3306,12 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
+
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
@@ -3377,7 +3412,7 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-throat@4.1.0, throat@^4.0.0:
+throat@^4.0.0, throat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
@@ -3591,13 +3626,6 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-worker-farm@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.0.tgz#adfdf0cd40581465ed0a1f648f9735722afd5c8d"
-  dependencies:
-    errno "^0.1.4"
-    xtend "^4.0.1"
-
 worker-farm@^1.3.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
@@ -3632,10 +3660,6 @@ write@^0.2.1:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
-
-xtend@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This adds support to pass through `contents` to the `precompile` options (matches the changes in https://github.com/ember-cli/ember-cli-htmlbars/commit/cae3b4fb0ec8ff1e2a748c9d226c13e0d3db6de4).

Notably, it does not add `moduleName` (as I don't want there to be conflicting meaning of `meta.moduleName` before https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile/pull/33 lands).