### PR TITLE
WIP: not sure if this is the correct failing test - hbs should be able to take a source argument

### DIFF
--- a/tests/parse-module-name.js
+++ b/tests/parse-module-name.js
@@ -3,6 +3,12 @@
 const parseModuleName = require('../lib/parse-module-name');
 
 describe('parse-module-name helper', function() {
+  it('should be able to take a path and prepend it when using a local component test', function() {
+    expect(
+      parseModuleName('emberconf/src/ui/components/foo-bar/baz/component-test.js', 'baz')
+    ).toEqual('src/ui/components/foo-bar/baz/template.hbs');
+  });
+
   it('should return application template when using a route local -component', function() {
     expect(
       parseModuleName('emberconf/src/ui/routes/application/-components/footer-prompt/component-test.js')


### PR DESCRIPTION
/cc @mixonic 

This is to maybe begin work on 

> hbs helpers should accept a source argument like templates in a running app do. In: https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile

from https://github.com/emberjs/ember.js/issues/16373

Just trying to determine what expected behavior is