### PR TITLE
Drop support for Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
   - "stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "6"
   - "8"
-  - "stable"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Clemens Müller <cmueller.418@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">= 4"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
should unblock several dependency updates