### PR TITLE
Migrate to building AST nodes instead of replacing with source.

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -23,7 +23,7 @@ describe("htmlbars-inline-precompile", function() {
       [HTMLBarsInlinePrecompile, {
         precompile(template, options) {
           optionsReceived = options;
-          return `precompiled(${template})`;
+          return `"precompiled(${template})"`;
         }
       }],
     ];
@@ -77,7 +77,7 @@ describe("htmlbars-inline-precompile", function() {
   it("replaces tagged template expressions with precompiled version", function() {
     let transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;");
 
-    expect(transformed).toEqual("var compiled = Ember.HTMLBars.template(precompiled(hello));", "tagged template is replaced");
+    expect(transformed).toEqual("var compiled = Ember.HTMLBars.template('precompiled(hello)');", "tagged template is replaced");
   });
 
   it("replaces tagged template expressions with precompiled version for custom import paths", function() {
@@ -85,7 +85,7 @@ describe("htmlbars-inline-precompile", function() {
 
     let transformed = transform("import hbs from 'ember-cli-htmlbars-inline-precompile';\nvar compiled = hbs`hello`;");
 
-    expect(transformed).toEqual("var compiled = Ember.HTMLBars.template(precompiled(hello));");
+    expect(transformed).toEqual("var compiled = Ember.HTMLBars.template('precompiled(hello)');");
   });
 
   it("does not cause an error when no import is found", function() {
@@ -101,7 +101,7 @@ describe("htmlbars-inline-precompile", function() {
       let b = otherHbs\`hello\`;
     `);
 
-    let expected = `let a = Ember.HTMLBars.template(precompiled(hello));\nlet b = Ember.HTMLBars.template(precompiled(hello));`;
+    let expected = `let a = Ember.HTMLBars.template('precompiled(hello)');\nlet b = Ember.HTMLBars.template('precompiled(hello)');`;
 
     expect(transformed).toEqual(expected, "tagged template is replaced");
   });
@@ -110,21 +110,21 @@ describe("htmlbars-inline-precompile", function() {
     plugins.push([TransformModules]);
     let transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;");
 
-    expect(transformed).toEqual(`define([], function () {\n  'use strict';\n\n  var compiled = Ember.HTMLBars.template(precompiled(hello));\n});`, "tagged template is replaced");
+    expect(transformed).toEqual(`define([], function () {\n  'use strict';\n\n  var compiled = Ember.HTMLBars.template('precompiled(hello)');\n});`, "tagged template is replaced");
   });
 
   it("works properly when used after modules transform", function() {
     plugins.unshift([TransformModules]);
     let transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;");
 
-    expect(transformed).toEqual(`define([], function () {\n  'use strict';\n\n  var compiled = Ember.HTMLBars.template(precompiled(hello));\n});`, "tagged template is replaced");
+    expect(transformed).toEqual(`define([], function () {\n  'use strict';\n\n  var compiled = Ember.HTMLBars.template('precompiled(hello)');\n});`, "tagged template is replaced");
   });
 
   it("replaces tagged template expressions when before babel-plugin-transform-es2015-template-literals", function() {
     plugins.push([TransformTemplateLiterals]);
     let transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;");
 
-    expect(transformed).toEqual("var compiled = Ember.HTMLBars.template(precompiled(hello));", "tagged template is replaced");
+    expect(transformed).toEqual("var compiled = Ember.HTMLBars.template('precompiled(hello)');", "tagged template is replaced");
   });
 
   it("doesn't replace unrelated tagged template strings", function() {
@@ -148,7 +148,7 @@ describe("htmlbars-inline-precompile", function() {
     it("works with a plain string as parameter hbs('string')", function() {
       let transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('hello');");
 
-      expect(transformed).toEqual("var compiled = Ember.HTMLBars.template(precompiled(hello));", "tagged template is replaced");
+      expect(transformed).toEqual("var compiled = Ember.HTMLBars.template('precompiled(hello)');", "tagged template is replaced");
     });
 
     it("warns when the second argument is not an object", function() {


### PR DESCRIPTION
This removes the `path.replaceWithSourceString` usage (which is generally discouraged) and replaces it with AST building. The result from the ember-template-compiler.js is a JSON.parse'able string which we can then use to build the actual AST nodes.