### PR TITLE
Ensure JSON.stringify'ed value is valid for hbs() options.

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -51,7 +51,9 @@ describe('htmlbars-inline-precompile', function() {
   it('allows static userland options when used as a call expression', function() {
     let source = 'hello';
     transform(
-      `import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('${source}', { parseOptions: { srcName: 'bar.hbs' }, moduleName: 'foo/bar.hbs', xyz: 123, qux: true });`
+      `import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('${source}', { parseOptions: { srcName: 'bar.hbs' }, moduleName: 'foo/bar.hbs', xyz: 123, qux: true, stringifiedThing: ${JSON.stringify(
+        { foo: 'baz' }
+      )}});`
     );
 
     expect(optionsReceived).toEqual({
@@ -60,6 +62,9 @@ describe('htmlbars-inline-precompile', function() {
       moduleName: 'foo/bar.hbs',
       xyz: 123,
       qux: true,
+      stringifiedThing: {
+        foo: 'baz',
+      },
     });
   });
 

--- a/index.js
+++ b/index.js
@@ -70,13 +70,16 @@ module.exports = function(babel) {
     let result = {};
 
     node.properties.forEach(property => {
-      if (property.computed || property.key.type !== 'Identifier') {
+      if (property.computed || !['Identifier', 'StringLiteral'].includes(property.key.type)) {
         throw buildError('hbs can only accept static options');
       }
 
+      let propertyName =
+        property.key.type === 'Identifier' ? property.key.name : property.key.value;
+
       let value = parseExpression(buildError, property.value);
 
-      result[property.key.name] = value;
+      result[propertyName] = value;
     });
 
     return result;


### PR DESCRIPTION
Previously, calling the `CallExpression` form of `hbs` with the result
from `JSON.stringify({ foo: 'bar' })` would error (because we only
allowed identifiers as keys in an `ObjectExpression`).