### PR TITLE
Ensure `*/` included in a template does break surrounding JS.

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -87,6 +87,25 @@ describe('htmlbars-inline-precompile', function() {
     `);
   });
 
+  it('escapes any */ included in the template string', function() {
+    let transformed = transform(stripIndent`
+      import hbs from 'htmlbars-inline-precompile';
+      if ('foo') {
+        const template = hbs\`hello */\`;
+      }
+    `);
+
+    expect(transformed).toEqual(stripIndent`
+      if ('foo') {
+        const template = Ember.HTMLBars.template(
+        /*
+          hello *\\/
+        */
+        "precompiled(hello */)");
+      }
+    `);
+  });
+
   it('passes options when used as a tagged template string', function() {
     let source = 'hello';
     transform(`import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs\`${source}\`;`);

--- a/index.js
+++ b/index.js
@@ -93,7 +93,12 @@ module.exports = function(babel) {
 
     let templateExpression = buildExpression(precompiled);
 
-    t.addComment(templateExpression, 'leading', `\n  ${template}\n`, /* line comment? */ false);
+    t.addComment(
+      templateExpression,
+      'leading',
+      `\n  ${template.replace(/\*\//g, '*\\/')}\n`,
+      /* line comment? */ false
+    );
 
     return t.callExpression(
       t.memberExpression(


### PR DESCRIPTION
Prior to this a template like:

```js
hbs`some content */`
```

Would emit invalid JS:

```js
Ember.HTMLBars.template(
  /*
    some content */
  */
  {
    // some stuff emitted by actual compilation
  }
)
```

The comment showing the original template was added as a developer aide (makes looking at files with many inline templates such as tests much easier), but without escaping `*/` we risk the template content itself breaking the JS parsing within the file.

This commit ensures that `*/` is escaped to `*\/` which avoids the issue.

Fixes https://github.com/ember-cli/ember-cli-htmlbars/issues/391