### PR TITLE
Add ability to transfer compilation errors into runtime.

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -87,6 +87,22 @@ describe('htmlbars-inline-precompile', function() {
     `);
   });
 
+  it('avoids a build time error when passed `insertRuntimeErrors`', function() {
+    precompile = () => {
+      throw new Error('NOOOOOOOOOOOOOOOOOOOOOO');
+    };
+
+    let transformed = transform(
+      `import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('hello', { insertRuntimeErrors: true });`
+    );
+
+    expect(transformed).toMatchInlineSnapshot(`
+      "var compiled = function () {
+        throw new Error(\\"NOOOOOOOOOOOOOOOOOOOOOO\\");
+      }();"
+    `);
+  });
+
   it('escapes any */ included in the template string', function() {
     let transformed = transform(stripIndent`
       import hbs from 'htmlbars-inline-precompile';


### PR DESCRIPTION
Invoking the `CallExpression` form with a special option `{ insertRuntimeErrors: true }` will prevent a compile time error and instead inline the error to be thrown at runtime.

So for example if a template compilation is going to error, we would transpile from:

```js
import { hbs } from 'ember-cli-htmlbars';

const layout = hbs('some bad template', { insertRuntimeErrors: true });
```

And assuming that this compilation would normally throw an error with the message `"ZOMG don't do this"`, you would have the following compilation output:

```js
const layout = function() {
  throw new Error("ZOMG don't do this');
}();
```