### PR TITLE
Avoid assuming ember-template-compiler result is JSON

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -39,6 +39,24 @@ describe('htmlbars-inline-precompile', function () {
     ];
   });
 
+  it('supports compilation that returns a non-JSON.parseable object', function () {
+    precompile = (template) => {
+      return `function() { return "${template}"; }`;
+    };
+
+    let transpiled = transform(
+      "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "var compiled = Ember.HTMLBars.template(
+      /*
+        hello
+      */
+      function() { return \\"hello\\"; });"
+    `);
+  });
+
   it('passes options when used as a call expression', function () {
     let source = 'hello';
     transform(`import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('${source}');`);

--- a/index.js
+++ b/index.js
@@ -6,45 +6,7 @@ module.exports = function (babel) {
   const runtimeErrorIIFE = babel.template(
     `(function() {\n  throw new Error('ERROR_MESSAGE');\n})();`
   );
-
-  function buildExpression(value) {
-    switch (typeof value) {
-      case 'string':
-        return t.stringLiteral(value);
-      case 'number':
-        return t.numberLiteral(value);
-      case 'boolean':
-        return t.booleanLiteral(value);
-      case 'object': {
-        if (Array.isArray(value)) {
-          return buildArrayExpression(value);
-        } else {
-          return buildObjectExpression(value);
-        }
-      }
-      default:
-        throw new Error(
-          `hbs compilation error; unexpected type from precompiler: ${typeof value} for ${JSON.stringify(
-            value
-          )}`
-        );
-    }
-  }
-
-  function buildObjectExpression(object) {
-    let properties = [];
-    for (let key in object) {
-      let value = object[key];
-
-      properties.push(t.objectProperty(t.identifier(key), buildExpression(value)));
-    }
-
-    return t.objectExpression(properties);
-  }
-
-  function buildArrayExpression(array) {
-    return t.arrayExpression(array.map((i) => buildExpression(i)));
-  }
+  const parsePrecompiledTemplate = babel.template('PRECOMPILED');
 
   function parseExpression(buildError, node) {
     switch (node.type) {
@@ -104,9 +66,9 @@ module.exports = function (babel) {
       precompileResult = precompile(template, options);
     }
 
-    let precompiled = JSON.parse(precompileResult);
-
-    let templateExpression = buildExpression(precompiled);
+    let templateExpression = parsePrecompiledTemplate({
+      PRECOMPILED: precompileResult,
+    }).expression;
 
     t.addComment(
       templateExpression,


### PR DESCRIPTION
It is fundamentally invalid to assume that `require(emberTemplateCompilerPath).precompile('{{something}}')` returns a `JSON.parse`able value.

New template features (strict mode, template imports, etc) will require the precompiled template to actually be a function (older Ember versions (prior to 2.10) also used functions).