### PR TITLE
[FEAT] Adds isProduction flag

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -66,6 +66,80 @@ describe('htmlbars-inline-precompile', function () {
     });
   });
 
+  it('passes through isProduction option when used as a call expression', function () {
+    let source = 'hello';
+
+    plugins = [
+      [
+        HTMLBarsInlinePrecompile,
+        {
+          precompile() {
+            return precompile.apply(this, arguments);
+          },
+
+          isProduction: true,
+        },
+      ],
+    ];
+
+    transform(`import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('${source}');`);
+
+    expect(optionsReceived).toEqual({
+      contents: source,
+      isProduction: true,
+    });
+  });
+
+  it('uses the user provided isProduction option if present', function () {
+    let source = 'hello';
+
+    plugins = [
+      [
+        HTMLBarsInlinePrecompile,
+        {
+          precompile() {
+            return precompile.apply(this, arguments);
+          },
+
+          isProduction: false,
+        },
+      ],
+    ];
+
+    transform(
+      `import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('${source}', { isProduction: true });`
+    );
+
+    expect(optionsReceived).toEqual({
+      contents: source,
+      isProduction: true,
+    });
+  });
+
+  it('passes through isProduction option when used as a TaggedTemplateExpression', function () {
+    let source = 'hello';
+
+    plugins = [
+      [
+        HTMLBarsInlinePrecompile,
+        {
+          precompile() {
+            return precompile.apply(this, arguments);
+          },
+
+          isProduction: true,
+        },
+      ],
+    ];
+
+    transform(`import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs\`${source}\`;`);
+
+    expect(optionsReceived).toEqual({
+      contents: source,
+      isProduction: true,
+    });
+  });
+
   it('allows a template string literal when used as a call expression', function () {
     let source = 'hello';
     transform(`import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs(\`${source}\`);`);

--- a/index.js
+++ b/index.js
@@ -153,7 +153,9 @@ module.exports = function (babel) {
 
         let template = path.node.quasi.quasis.map((quasi) => quasi.value.cooked).join('');
 
-        path.replaceWith(compileTemplate(state.opts.precompile, template));
+        let { precompile, isProduction } = state.opts;
+
+        path.replaceWith(compileTemplate(precompile, template, { isProduction }));
       },
 
       CallExpression(path, state) {
@@ -195,6 +197,7 @@ module.exports = function (babel) {
 
         switch (args.length) {
           case 1:
+            options = {};
             break;
           case 2: {
             if (args[1].type !== 'ObjectExpression') {
@@ -213,7 +216,12 @@ module.exports = function (babel) {
             );
         }
 
-        let { precompile } = state.opts;
+        let { precompile, isProduction } = state.opts;
+
+        // allow the user specified value to "win" over ours
+        if (!('isProduction' in options)) {
+          options.isProduction = isProduction;
+        }
 
         path.replaceWith(compileTemplate(precompile, template, options));
       },


### PR DESCRIPTION
This flag allows the template compiler to have different behavior in production vs development builds.

Leverages the work introduced in https://github.com/emberjs/ember.js/pull/19081.