### PR TITLE
Fix issues when using emoji in templates while transpiling for IE11

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -54,7 +54,9 @@ describe('htmlbars-inline-precompile', function () {
       /*
         hello
       */
-      function() { return \\"hello\\"; });"
+      function () {
+        return \\"hello\\";
+      });"
     `);
   });
 
@@ -366,10 +368,13 @@ describe('htmlbars-inline-precompile', function () {
       "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('some emoji goes 💥');"
     );
 
-    expect(transformed).toEqual(
-      `define([], function () {\n  "use strict";\n\n  var compiled = Ember.HTMLBars.template(\n  /*\n    some emoji goes 💥\n  */\n  "precompiled(some emoji goes 💥)");\n});`,
-      'tagged template is replaced'
-    );
+    expect(transformed).toMatchInlineSnapshot(`
+      "var compiled = Ember.HTMLBars.template(
+      /*
+        some emoji goes 💥
+      */
+      \\"precompiled(some emoji goes 💥)\\");"
+    `);
   });
 
   it('replaces tagged template expressions when before babel-plugin-transform-es2015-template-literals', function () {

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -6,6 +6,7 @@ const babel = require('@babel/core');
 const HTMLBarsInlinePrecompile = require('../index');
 const TransformTemplateLiterals = require('@babel/plugin-transform-template-literals');
 const TransformModules = require('@babel/plugin-transform-modules-amd');
+const TransformUnicodeEscapes = require('@babel/plugin-transform-unicode-escapes');
 const { stripIndent } = require('common-tags');
 
 describe('htmlbars-inline-precompile', function () {
@@ -355,6 +356,18 @@ describe('htmlbars-inline-precompile', function () {
 
     expect(transformed).toEqual(
       `define([], function () {\n  "use strict";\n\n  var compiled = Ember.HTMLBars.template(\n  /*\n    hello\n  */\n  "precompiled(hello)");\n});`,
+      'tagged template is replaced'
+    );
+  });
+
+  it('works properly when used along with @babel/plugin-transform-unicode-escapes', function () {
+    plugins.push([TransformUnicodeEscapes]);
+    let transformed = transform(
+      "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('some emoji goes 💥');"
+    );
+
+    expect(transformed).toEqual(
+      `define([], function () {\n  "use strict";\n\n  var compiled = Ember.HTMLBars.template(\n  /*\n    some emoji goes 💥\n  */\n  "precompiled(some emoji goes 💥)");\n});`,
       'tagged template is replaced'
     );
   });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-modules-amd": "^7.12.1",
     "@babel/plugin-transform-template-literals": "^7.12.1",
+    "@babel/plugin-transform-unicode-escapes": "^7.12.1",
     "common-tags": "^1.8.0",
     "ember-source": "^3.22.0",
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,6 +820,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-unicode-escapes@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz#5232b9f81ccb07070b7c3c36c67a1b78f1845709"
+  integrity sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
 "@babel/plugin-transform-unicode-regex@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz#e56d71f9282fac6db09c82742055576d5e6d80a8"


### PR DESCRIPTION
This reproduces the failure in https://github.com/emberjs/ember.js/issues/19251.
