### PR TITLE
Adds `useEmberModule` option

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -468,4 +468,63 @@ describe('htmlbars-inline-precompile', function () {
       expect(transformed).toContain(`hello {{firstName}}`);
     });
   });
+
+  describe('with Ember imports', function () {
+    it('adds an Ember import if useEmberModule is set to true', function () {
+      plugins = [
+        [
+          HTMLBarsInlinePrecompile,
+          {
+            precompile() {
+              return precompile.apply(this, arguments);
+            },
+
+            useEmberModule: true,
+          },
+        ],
+      ];
+
+      let transpiled = transform(
+        "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "import _Ember from \\"ember\\";
+
+        var compiled = _Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\");"
+      `);
+    });
+
+    it('Uses existing Ember import if one exists', function () {
+      plugins = [
+        [
+          HTMLBarsInlinePrecompile,
+          {
+            precompile() {
+              return precompile.apply(this, arguments);
+            },
+
+            useEmberModule: true,
+          },
+        ],
+      ];
+
+      let transpiled = transform(
+        "import Foo from 'ember';\nimport hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "import Foo from 'ember';
+        var compiled = Foo.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\");"
+      `);
+    });
+  });
 });


### PR DESCRIPTION
Adds an option to import `Ember` rather than relying on the global. This
will allow this babel plugin to continue working after the global has
been deprecated.

Related to: https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/pull/175