### PR TITLE
Implements an option to support the template literal imports proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",
+    "@babel/plugin-proposal-class-properties": "^7.12.13",
     "@babel/plugin-transform-modules-amd": "^7.12.13",
     "@babel/plugin-transform-template-literals": "^7.12.13",
     "@babel/plugin-transform-unicode-escapes": "^7.12.13",

--- a/src/template-literal-transform.js
+++ b/src/template-literal-transform.js
@@ -1,0 +1,92 @@
+const filePath = require('path');
+
+module.exports.replaceTemplateLiteralProposal = function (t, path, state, compiled, options) {
+  let version = options.useTemplateLiteralProposalSemantics;
+
+  if (typeof version !== 'number' || version !== 1) {
+    throw path.buildCodeFrameError(
+      'Passed an invalid version for useTemplateLiteralProposalSemantics. This option must be assign a version number. The current valid version numbers are: 1'
+    );
+  }
+
+  let { parentPath } = path;
+  let filename = filePath.parse(state.file.opts.filename).name;
+
+  if (parentPath.type === 'VariableDeclarator') {
+    let varId = parentPath.node.id;
+    let varDeclaration = parentPath.parentPath;
+
+    varDeclaration.insertAfter(
+      t.expressionStatement(
+        t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
+          compiled,
+          varId,
+        ])
+      )
+    );
+    path.replaceWith(
+      t.callExpression(state.ensureImport('templateOnly', '@ember/component/template-only'), [
+        t.stringLiteral(filename),
+        t.stringLiteral(varId.name),
+      ])
+    );
+  } else if (parentPath.node.type === 'ExportDefaultDeclaration') {
+    let varId = path.scope.generateUidIdentifier(filename);
+
+    parentPath.insertBefore(
+      t.variableDeclaration('const', [
+        t.variableDeclarator(
+          varId,
+          t.callExpression(state.ensureImport('templateOnly', '@ember/component/template-only'), [
+            t.stringLiteral(filename),
+            t.stringLiteral(varId.name),
+          ])
+        ),
+      ])
+    );
+    parentPath.insertBefore(
+      t.expressionStatement(
+        t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
+          compiled,
+          varId,
+        ])
+      )
+    );
+    path.replaceWith(varId);
+  } else if (parentPath.node.type === 'ClassProperty') {
+    if (parentPath.node.static !== true) {
+      throw path.buildCodeFrameError(
+        `Attempted to use \`${options.originalName}\` with a non-static class field. Templates declared with this helper must be assigned to the \`static template\` class field`
+      );
+    }
+
+    if (parentPath.node.key.name !== 'template') {
+      throw path.buildCodeFrameError(
+        `Attempted to use \`${options.originalName}\` with the ${parentPath.node.key.name} class property. Templates declared with this helper must be assigned to the \`static template\` class field`
+      );
+    }
+
+    let classDeclaration = parentPath.parentPath.parentPath;
+
+    if (classDeclaration.node.type !== 'ClassDeclaration') {
+      throw path.buildCodeFrameError(
+        `Attempted to use \`${options.originalName}\` to define a template for an anonymous class. Templates declared with this helper must be assigned to classes which have a name.`
+      );
+    }
+
+    classDeclaration.insertAfter(
+      t.expressionStatement(
+        t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
+          compiled,
+          classDeclaration.node.id,
+        ])
+      )
+    );
+
+    parentPath.remove();
+  } else {
+    throw path.buildCodeFrameError(
+      `Attempted to use \`${options.originalName}\` to define a template in an unsupported way. Templates defined using this helper must be:\n\n1. Assigned to a variable declaration OR\n2. The default export of a file OR\n3. Assigned to the \`static template\` field of a named class`
+    );
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,17 @@
     "@babel/helper-replace-supers" "^7.12.1"
     "@babel/helper-split-export-declaration" "^7.10.4"
 
+"@babel/helper-create-class-features-plugin@^7.12.13":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.17.tgz#704b69c8a78d03fb1c5fcc2e7b593f8a65628944"
+  integrity sha512-I/nurmTxIxHV0M+rIpfQBF1oN342+yvl2kwZUrQuOClMamHF1w5tknfZubgNOLRoA73SzBFAdFcpb4M9HwOeWQ==
+  dependencies:
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-member-expression-to-functions" "^7.12.17"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/helper-replace-supers" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+
 "@babel/helper-create-regexp-features-plugin@^7.12.1":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz#2084172e95443fa0a09214ba1bb328f9aea1278f"
@@ -183,6 +194,13 @@
   integrity sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-member-expression-to-functions@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.17.tgz#f82838eb06e1235307b6d71457b6670ff71ee5ac"
+  integrity sha512-Bzv4p3ODgS/qpBE0DiJ9qf5WxSmrQ8gVTe8ClMfwwsY2x/rhykxxy3bXzG7AGTnPB2ij37zGJ/Q/6FruxHxsxg==
+  dependencies:
+    "@babel/types" "^7.12.17"
 
 "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.8.3":
   version "7.12.13"
@@ -378,6 +396,14 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-proposal-class-properties@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.13.tgz#3d2ce350367058033c93c098e348161d6dc0d8c8"
+  integrity sha512-8SCJ0Ddrpwv4T7Gwb33EmW1V9PY5lggTO+A8WjyIwxrSHDUyBw4MtF96ifn1n8H806YlxbVCoKXbbmzD6RD+cA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/plugin-proposal-decorators@^7.10.5":
   version "7.12.12"
@@ -1036,6 +1062,15 @@
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.13.tgz#8be1aa8f2c876da11a9cf650c0ecf656913ad611"
   integrity sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.17.tgz#9d711eb807e0934c90b8b1ca0eb1f7230d150963"
+  integrity sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"


### PR DESCRIPTION
Implements the `useTemplateLiteralProposalSemantics` option for individual
modules. This proposal is outlined in the README for the
template-imports addon, [here](https://github.com/ember-template-imports/ember-template-imports#using-template-literals-with-hbs)