### PR TITLE
Refactor to use `createTemplateFactory`

### DIFF
--- a/__tests__/template-literal-tests.js
+++ b/__tests__/template-literal-tests.js
@@ -1,0 +1,376 @@
+'use strict';
+
+const babel = require('@babel/core');
+const HTMLBarsInlinePrecompile = require('../index');
+
+describe('htmlbars-inline-precompile: useTemplateLiteralProposalSemantics', function () {
+  let precompile, plugins, optionsReceived;
+
+  function transform(code) {
+    return babel
+      .transform(code, {
+        filename: 'foo-bar.js',
+        plugins,
+      })
+      .code.trim();
+  }
+
+  beforeEach(function () {
+    optionsReceived = undefined;
+    precompile = (template, options) => {
+      optionsReceived = options;
+      return `"precompiled(${template})"`;
+    };
+
+    plugins = [
+      [
+        HTMLBarsInlinePrecompile,
+        {
+          precompile() {
+            return precompile.apply(this, arguments);
+          },
+
+          modules: {
+            'ember-template-imports': {
+              export: 'hbs',
+              useTemplateLiteralProposalSemantics: 1,
+            },
+          },
+        },
+      ],
+      '@babel/plugin-proposal-class-properties',
+    ];
+  });
+
+  it('works with templates assigned to variables', function () {
+    let transpiled = transform(
+      `
+        import { hbs } from 'ember-template-imports';
+
+        const Foo = hbs\`hello\`;
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import _emberComponentTemplateOnly from \\"@ember/component/template-only\\";
+      import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      const Foo = _emberComponentTemplateOnly(\\"foo-bar\\", \\"Foo\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('works with templates exported as the default', function () {
+    let transpiled = transform(
+      `
+        import { hbs } from 'ember-template-imports';
+
+        export default hbs\`hello\`;
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import _emberComponentTemplateOnly from \\"@ember/component/template-only\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      const _fooBar = _emberComponentTemplateOnly(\\"foo-bar\\", \\"_fooBar\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), _fooBar);
+
+      export default _fooBar;"
+    `);
+  });
+
+  it('works with templates assigned to classes', function () {
+    let transpiled = transform(
+      `
+        import { hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs\`hello\`;
+        }
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      class Foo {}
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('works with templates assigned to class expressions', function () {
+    let transpiled = transform(
+      `
+        import { hbs } from 'ember-template-imports';
+
+        const Foo = class {
+          static template = hbs\`hello\`;
+        }
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      const Foo = _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), class {});"
+    `);
+  });
+
+  it('works with templates assigned to export classes', function () {
+    let transpiled = transform(
+      `
+        import { hbs } from 'ember-template-imports';
+
+        export class Foo {
+          static template = hbs\`hello\`;
+        }
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+      export class Foo {}
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('works with templates assigned to export default classes', function () {
+    let transpiled = transform(
+      `
+        import { hbs } from 'ember-template-imports';
+
+        export default class Foo {
+          static template = hbs\`hello\`;
+        }
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+      export default class Foo {}
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('correctly handles scope', function () {
+    let source = 'hello';
+    transform(
+      `
+        import { hbs } from 'ember-template-imports';
+        import baz from 'qux';
+
+        let foo = 123;
+        const bar = 456;
+
+        export default hbs\`${source}\`;
+      `
+    );
+
+    expect(optionsReceived).toEqual({
+      contents: source,
+      isProduction: undefined,
+      scope: ['baz', 'foo', 'bar'],
+      strict: true,
+    });
+  });
+
+  it('errors if used in an incorrect positions', function () {
+    expect(() => {
+      transform("import { hbs } from 'ember-template-imports';\nhbs`hello`;");
+    }).toThrow(
+      /Attempted to use `hbs` to define a template in an unsupported way. Templates defined using this helper must be:/
+    );
+
+    expect(() => {
+      transform("import { hbs } from 'ember-template-imports';\nfunc(hbs`hello`);");
+    }).toThrow(
+      /Attempted to use `hbs` to define a template in an unsupported way. Templates defined using this helper must be:/
+    );
+  });
+
+  it('errors if passed incorrect useTemplateLiteralProposalSemantics version', function () {
+    plugins[0][1].modules['ember-template-imports'].useTemplateLiteralProposalSemantics = true;
+
+    expect(() => {
+      transform(
+        `
+          import { hbs } from 'ember-template-imports';
+
+          const Foo = hbs\`hello\`;
+        `
+      );
+    }).toThrow(
+      /Passed an invalid version for useTemplateLiteralProposalSemantics. This option must be assign a version number. The current valid version numbers are: 1/
+    );
+  });
+
+  describe('with babel-plugin-ember-modules-api-polyfill', function () {
+    beforeEach(() => {
+      plugins.push('babel-plugin-ember-modules-api-polyfill');
+    });
+
+    it('works with templates assigned to variables', function () {
+      let transpiled = transform(
+        `
+          import { hbs } from 'ember-template-imports';
+
+          const Foo = hbs\`hello\`;
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "const Foo = Ember._templateOnlyComponent(\\"foo-bar\\", \\"Foo\\");
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates exported as the default', function () {
+      let transpiled = transform(
+        `
+          import { hbs } from 'ember-template-imports';
+
+          export default hbs\`hello\`;
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "const _fooBar = Ember._templateOnlyComponent(\\"foo-bar\\", \\"_fooBar\\");
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), _fooBar);
+
+        export default _fooBar;"
+      `);
+    });
+
+    it('works with templates assigned to classes', function () {
+      let transpiled = transform(
+        `
+          import { hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`hello\`;
+          }
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "class Foo {}
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates assigned to export classes', function () {
+      let transpiled = transform(
+        `
+          import { hbs } from 'ember-template-imports';
+
+          export class Foo {
+            static template = hbs\`hello\`;
+          }
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "export class Foo {}
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates assigned to export default classes', function () {
+      let transpiled = transform(
+        `
+          import { hbs } from 'ember-template-imports';
+
+          export default class Foo {
+            static template = hbs\`hello\`;
+          }
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "export default class Foo {}
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates assigned to class expressions', function () {
+      let transpiled = transform(
+        `
+          import { hbs } from 'ember-template-imports';
+
+          const Foo = class {
+            static template = hbs\`hello\`;
+          }
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "const Foo = Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), class {});"
+      `);
+    });
+  });
+});

--- a/__tests__/template-tag-tests.js
+++ b/__tests__/template-tag-tests.js
@@ -1,0 +1,473 @@
+'use strict';
+
+const babel = require('@babel/core');
+const HTMLBarsInlinePrecompile = require('../index');
+
+describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function () {
+  let precompile, plugins, optionsReceived;
+
+  function transform(code) {
+    return babel
+      .transform(code, {
+        filename: 'foo-bar.js',
+        plugins,
+      })
+      .code.trim();
+  }
+
+  beforeEach(function () {
+    optionsReceived = undefined;
+    precompile = (template, options) => {
+      optionsReceived = options;
+      return `"precompiled(${template})"`;
+    };
+
+    plugins = [
+      [
+        HTMLBarsInlinePrecompile,
+        {
+          precompile() {
+            return precompile.apply(this, arguments);
+          },
+
+          modules: {
+            'TEMPLATE-TAG-MODULE': {
+              export: 'GLIMMER_TEMPLATE',
+              debugName: '<template>',
+              useTemplateTagProposalSemantics: 1,
+            },
+          },
+        },
+      ],
+      '@babel/plugin-proposal-class-properties',
+    ];
+  });
+
+  it('works with templates assigned to variables', function () {
+    let transpiled = transform(
+      `
+        const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import _emberComponentTemplateOnly from \\"@ember/component/template-only\\";
+      import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      const Foo = _emberComponentTemplateOnly(\\"foo-bar\\", \\"Foo\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('works with templates exported as variables', function () {
+    let transpiled = transform(
+      `
+        export const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import _emberComponentTemplateOnly from \\"@ember/component/template-only\\";
+      import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+      export const Foo = _emberComponentTemplateOnly(\\"foo-bar\\", \\"Foo\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('works with templates exported as the default', function () {
+    let transpiled = transform(
+      `
+        export default [GLIMMER_TEMPLATE(\`hello\`)];
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import _emberComponentTemplateOnly from \\"@ember/component/template-only\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      const _fooBar = _emberComponentTemplateOnly(\\"foo-bar\\", \\"_fooBar\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), _fooBar);
+
+      export default _fooBar;"
+    `);
+  });
+
+  it('works with templates defined at the top level', function () {
+    let transpiled = transform(
+      `
+        [GLIMMER_TEMPLATE(\`hello\`)];
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import _emberComponentTemplateOnly from \\"@ember/component/template-only\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      const _fooBar = _emberComponentTemplateOnly(\\"foo-bar\\", \\"_fooBar\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), _fooBar);
+
+      export default _fooBar;"
+    `);
+  });
+
+  it('works with templates assigned to classes', function () {
+    let transpiled = transform(
+      `
+        class Foo {
+          [GLIMMER_TEMPLATE(\`hello\`)];
+        }
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      class Foo {}
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('works with templates assigned to export classes', function () {
+    let transpiled = transform(
+      `
+        export class Foo {
+          [GLIMMER_TEMPLATE(\`hello\`)];
+        }
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+      export class Foo {}
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('works with templates assigned to export default classes', function () {
+    let transpiled = transform(
+      `
+        export default class Foo {
+          [GLIMMER_TEMPLATE(\`hello\`)];
+        }
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+      export default class Foo {}
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
+  it('works with templates assigned to class expressions', function () {
+    let transpiled = transform(
+      `
+        const Foo = class {
+          [GLIMMER_TEMPLATE(\`hello\`)];
+        }
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      const Foo = _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), class {});"
+    `);
+  });
+
+  it('correctly handles scope', function () {
+    let source = 'hello';
+    transform(
+      `
+        import baz from 'qux';
+
+        let foo = 123;
+        const bar = 456;
+
+        export default [GLIMMER_TEMPLATE(\`${source}\`)];
+      `
+    );
+
+    expect(optionsReceived).toEqual({
+      contents: source,
+      isProduction: undefined,
+      scope: ['baz', 'foo', 'bar'],
+      strict: true,
+    });
+  });
+
+  it('errors if used in an incorrect positions', function () {
+    expect(() => {
+      transform("func([GLIMMER_TEMPLATE('hello')]);");
+    }).toThrow(
+      /Attempted to use `<template>` to define a template in an unsupported way. Templates defined using this syntax must be:/
+    );
+  });
+
+  it('errors if used with template literal syntax', function () {
+    plugins[0][1].modules['TEMPLATE-TAG-MODULE'].useTemplateLiteralProposalSemantics = 1;
+
+    expect(() => {
+      transform("func([GLIMMER_TEMPLATE('hello')]);");
+    }).toThrow(/Cannot use both the template literal and template tag syntax proposals together/);
+  });
+
+  it('errors if passed incorrect useTemplateTagProposalSemantics version', function () {
+    plugins[0][1].modules['TEMPLATE-TAG-MODULE'].useTemplateTagProposalSemantics = true;
+
+    expect(() => {
+      transform(
+        `
+          const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
+        `
+      );
+    }).toThrow(
+      /Passed an invalid version for useTemplateTagProposalSemantics. This option must be assign a version number. The current valid version numbers are: 1/
+    );
+  });
+
+  it('works alongside useTemplateLiteralProposalSemantics', function () {
+    plugins[0][1].modules['ember-template-imports'] = {
+      export: 'hbs',
+      useTemplateLiteralProposalSemantics: 1,
+    };
+
+    let transpiled = transform(
+      `
+        import { hbs } from 'ember-template-imports';
+
+        const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
+        const Bar = hbs\`hello\`;
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import _emberComponentTemplateOnly from \\"@ember/component/template-only\\";
+      import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      const Foo = _emberComponentTemplateOnly(\\"foo-bar\\", \\"Foo\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);
+
+      const Bar = _emberComponentTemplateOnly(\\"foo-bar\\", \\"Bar\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Bar);"
+    `);
+  });
+
+  describe('with babel-plugin-ember-modules-api-polyfill', function () {
+    beforeEach(() => {
+      plugins.push('babel-plugin-ember-modules-api-polyfill');
+    });
+
+    it('works with templates assigned to variables', function () {
+      let transpiled = transform(
+        `
+          const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "const Foo = Ember._templateOnlyComponent(\\"foo-bar\\", \\"Foo\\");
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates exported as variables', function () {
+      let transpiled = transform(
+        `
+          export const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "export const Foo = Ember._templateOnlyComponent(\\"foo-bar\\", \\"Foo\\");
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates exported as the default', function () {
+      let transpiled = transform(
+        `
+          export default [GLIMMER_TEMPLATE(\`hello\`)];
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "const _fooBar = Ember._templateOnlyComponent(\\"foo-bar\\", \\"_fooBar\\");
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), _fooBar);
+
+        export default _fooBar;"
+      `);
+    });
+
+    it('works with templates defined at the top level', function () {
+      let transpiled = transform(
+        `
+          [GLIMMER_TEMPLATE(\`hello\`)];
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "const _fooBar = Ember._templateOnlyComponent(\\"foo-bar\\", \\"_fooBar\\");
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), _fooBar);
+
+        export default _fooBar;"
+      `);
+    });
+
+    it('works with templates assigned to classes', function () {
+      let transpiled = transform(
+        `
+          class Foo {
+            [GLIMMER_TEMPLATE(\`hello\`)];
+          }
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "class Foo {}
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates assigned to export classes', function () {
+      let transpiled = transform(
+        `
+          export class Foo {
+            [GLIMMER_TEMPLATE(\`hello\`)];
+          }
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "export class Foo {}
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates assigned to export default classes', function () {
+      let transpiled = transform(
+        `
+          export default class Foo {
+            [GLIMMER_TEMPLATE(\`hello\`)];
+          }
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "export default class Foo {}
+
+        Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), Foo);"
+      `);
+    });
+
+    it('works with templates assigned to class expressions', function () {
+      let transpiled = transform(
+        `
+          const Foo = class {
+            [GLIMMER_TEMPLATE(\`hello\`)];
+          }
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "const Foo = Ember._setComponentTemplate(Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\"), class {});"
+      `);
+    });
+  });
+});

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -50,7 +50,9 @@ describe('htmlbars-inline-precompile', function () {
     );
 
     expect(transpiled).toMatchInlineSnapshot(`
-      "var compiled = Ember.HTMLBars.template(
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
       /*
         hello
       */
@@ -198,8 +200,10 @@ describe('htmlbars-inline-precompile', function () {
     `);
 
     expect(transformed).toEqual(stripIndent`
+      import { createTemplateFactory as _createTemplateFactory } from "@ember/template-factory";
+
       if ('foo') {
-        const template = Ember.HTMLBars.template(
+        const template = _createTemplateFactory(
         /*
           hello
         */
@@ -218,7 +222,9 @@ describe('htmlbars-inline-precompile', function () {
     );
 
     expect(transformed).toMatchInlineSnapshot(`
-      "var compiled = function () {
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = function () {
         throw new Error(\\"NOOOOOOOOOOOOOOOOOOOOOO\\");
       }();"
     `);
@@ -233,8 +239,10 @@ describe('htmlbars-inline-precompile', function () {
     `);
 
     expect(transformed).toEqual(stripIndent`
+      import { createTemplateFactory as _createTemplateFactory } from "@ember/template-factory";
+
       if ('foo') {
-        const template = Ember.HTMLBars.template(
+        const template = _createTemplateFactory(
         /*
           hello *\\/
         */
@@ -268,10 +276,15 @@ describe('htmlbars-inline-precompile', function () {
       "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
     );
 
-    expect(transformed).toEqual(
-      'var compiled = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");',
-      'tagged template is replaced'
-    );
+    expect(transformed).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");"
+    `);
   });
 
   it('replaces tagged template expressions with precompiled version for custom import paths with named exports', function () {
@@ -281,9 +294,15 @@ describe('htmlbars-inline-precompile', function () {
 
     let transformed = transform("import { baz } from 'foo-bar';\nvar compiled = baz`hello`;");
 
-    expect(transformed).toEqual(
-      'var compiled = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");'
-    );
+    expect(transformed).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");"
+    `);
   });
 
   it('replaces tagged template expressions with precompiled version for custom import paths', function () {
@@ -293,9 +312,15 @@ describe('htmlbars-inline-precompile', function () {
       "import hbs from 'ember-cli-htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
     );
 
-    expect(transformed).toEqual(
-      'var compiled = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");'
-    );
+    expect(transformed).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");"
+    `);
   });
 
   it('does not cause an error when no import is found', function () {
@@ -311,9 +336,21 @@ describe('htmlbars-inline-precompile', function () {
       let b = otherHbs\`hello\`;
     `);
 
-    let expected = `let a = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");\nlet b = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");`;
+    expect(transformed).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
 
-    expect(transformed).toEqual(expected, 'tagged template is replaced');
+      let a = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");
+
+      let b = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");"
+    `);
   });
 
   it('does not fully remove imports that have other imports', function () {
@@ -333,20 +370,24 @@ describe('htmlbars-inline-precompile', function () {
     `);
 
     expect(transformed).toMatchInlineSnapshot(`
-      "import { foo } from 'precompile1';
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+      import { foo } from 'precompile1';
       import { bar } from 'precompile2';
       import baz from 'precompile3';
-      let a = Ember.HTMLBars.template(
+
+      let a = _createTemplateFactory(
       /*
         hello
       */
       \\"precompiled(hello)\\");
-      let b = Ember.HTMLBars.template(
+
+      let b = _createTemplateFactory(
       /*
         hello
       */
       \\"precompiled(hello)\\");
-      let c = Ember.HTMLBars.template(
+
+      let c = _createTemplateFactory(
       /*
         hello
       */
@@ -380,9 +421,21 @@ describe('htmlbars-inline-precompile', function () {
       let b = precompileTemplate('hello');
     `);
 
-    let expected = `let a = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");\nlet b = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");`;
+    expect(transformed).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
 
-    expect(transformed).toEqual(expected, 'tagged template is replaced');
+      let a = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");
+
+      let b = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");"
+    `);
   });
 
   it('can disable template literal usage', function () {
@@ -449,10 +502,17 @@ describe('htmlbars-inline-precompile', function () {
       "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
     );
 
-    expect(transformed).toEqual(
-      `define([], function () {\n  "use strict";\n\n  var compiled = Ember.HTMLBars.template(\n  /*\n    hello\n  */\n  "precompiled(hello)");\n});`,
-      'tagged template is replaced'
-    );
+    expect(transformed).toMatchInlineSnapshot(`
+      "define([\\"@ember/template-factory\\"], function (_templateFactory) {
+        \\"use strict\\";
+
+        var compiled = (0, _templateFactory.createTemplateFactory)(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\");
+      });"
+    `);
   });
 
   it('works properly when used after modules transform', function () {
@@ -461,10 +521,17 @@ describe('htmlbars-inline-precompile', function () {
       "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
     );
 
-    expect(transformed).toEqual(
-      `define([], function () {\n  "use strict";\n\n  var compiled = Ember.HTMLBars.template(\n  /*\n    hello\n  */\n  "precompiled(hello)");\n});`,
-      'tagged template is replaced'
-    );
+    expect(transformed).toMatchInlineSnapshot(`
+      "define([\\"@ember/template-factory\\"], function (_templateFactory) {
+        \\"use strict\\";
+
+        var compiled = (0, _templateFactory.createTemplateFactory)(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\");
+      });"
+    `);
   });
 
   it('works properly when used along with @babel/plugin-transform-unicode-escapes', function () {
@@ -474,7 +541,9 @@ describe('htmlbars-inline-precompile', function () {
     );
 
     expect(transformed).toMatchInlineSnapshot(`
-      "var compiled = Ember.HTMLBars.template(
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
       /*
         some emoji goes 💥
       */
@@ -488,10 +557,15 @@ describe('htmlbars-inline-precompile', function () {
       "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
     );
 
-    expect(transformed).toEqual(
-      'var compiled = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");',
-      'tagged template is replaced'
-    );
+    expect(transformed).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");"
+    `);
   });
 
   it("doesn't replace unrelated tagged template strings", function () {
@@ -525,10 +599,15 @@ describe('htmlbars-inline-precompile', function () {
         "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('hello');"
       );
 
-      expect(transformed).toEqual(
-        'var compiled = Ember.HTMLBars.template(\n/*\n  hello\n*/\n"precompiled(hello)");',
-        'tagged template is replaced'
-      );
+      expect(transformed).toMatchInlineSnapshot(`
+        "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+        var compiled = _createTemplateFactory(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\");"
+      `);
     });
 
     it('warns when the second argument is not an object', function () {
@@ -552,6 +631,28 @@ describe('htmlbars-inline-precompile', function () {
         transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs();")
       ).toThrow(/hbs should be invoked with at least a single argument: the template string/);
     });
+
+    it('works with babel-plugin-ember-modules-api-polyfill', function () {
+      plugins.push('babel-plugin-ember-modules-api-polyfill');
+
+      precompile = (template) => {
+        return `function() { return "${template}"; }`;
+      };
+
+      let transpiled = transform(
+        "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "var compiled = Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        function () {
+          return \\"hello\\";
+        });"
+      `);
+    });
   });
 
   describe('with ember-source', function () {
@@ -571,65 +672,6 @@ describe('htmlbars-inline-precompile', function () {
       `);
 
       expect(transformed).toContain(`hello {{firstName}}`);
-    });
-  });
-
-  describe('with Ember imports', function () {
-    it('adds an Ember import if useEmberModule is set to true', function () {
-      plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          {
-            precompile() {
-              return precompile.apply(this, arguments);
-            },
-
-            useEmberModule: true,
-          },
-        ],
-      ];
-
-      let transpiled = transform(
-        "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import _ember from \\"ember\\";
-
-        var compiled = _ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\");"
-      `);
-    });
-
-    it('Uses existing Ember import if one exists', function () {
-      plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          {
-            precompile() {
-              return precompile.apply(this, arguments);
-            },
-
-            useEmberModule: true,
-          },
-        ],
-      ];
-
-      let transpiled = transform(
-        "import Foo from 'ember';\nimport hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import Foo from 'ember';
-        var compiled = Foo.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\");"
-      `);
     });
   });
 
@@ -693,379 +735,6 @@ describe('htmlbars-inline-precompile', function () {
         );
       }).toThrow(
         /Scope objects for `precompileTemplate` may only contain direct references to in-scope values, e.g. { bar } or { bar: bar }/
-      );
-    });
-  });
-
-  describe('with useTemplateLiteralProposalSemantics', function () {
-    beforeEach(() => {
-      plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          {
-            precompile() {
-              return precompile.apply(this, arguments);
-            },
-
-            modules: {
-              'ember-template-imports': {
-                export: 'hbs',
-                useTemplateLiteralProposalSemantics: 1,
-              },
-            },
-          },
-        ],
-        '@babel/plugin-proposal-class-properties',
-      ];
-    });
-
-    it('works with templates assigned to variables', function () {
-      let transpiled = transform(
-        `
-          import { hbs } from 'ember-template-imports';
-
-          const Foo = hbs\`hello\`;
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { templateOnly as _templateOnly } from \\"@ember/component/template-only\\";
-        import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-
-        const Foo = _templateOnly(\\"foo-bar\\", \\"Foo\\");
-
-        _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), Foo);"
-      `);
-    });
-
-    it('works with templates exported as the default', function () {
-      let transpiled = transform(
-        `
-          import { hbs } from 'ember-template-imports';
-
-          export default hbs\`hello\`;
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-        import { templateOnly as _templateOnly } from \\"@ember/component/template-only\\";
-
-        const _fooBar = _templateOnly(\\"foo-bar\\", \\"_fooBar\\");
-
-        _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), _fooBar);
-
-        export default _fooBar;"
-      `);
-    });
-
-    it('works with templates assigned to classes', function () {
-      let transpiled = transform(
-        `
-          import { hbs } from 'ember-template-imports';
-
-          class Foo {
-            static template = hbs\`hello\`;
-          }
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-
-        class Foo {}
-
-        _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), Foo);"
-      `);
-    });
-
-    it('works with templates assigned to class expressions', function () {
-      let transpiled = transform(
-        `
-          import { hbs } from 'ember-template-imports';
-
-          const Foo = class {
-            static template = hbs\`hello\`;
-          }
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-
-        const Foo = _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), class {});"
-      `);
-    });
-
-    it('correctly handles scope', function () {
-      let source = 'hello';
-      transform(
-        `
-          import { hbs } from 'ember-template-imports';
-          import baz from 'qux';
-
-          let foo = 123;
-          const bar = 456;
-
-          export default hbs\`${source}\`;
-        `
-      );
-
-      expect(optionsReceived).toEqual({
-        contents: source,
-        isProduction: undefined,
-        scope: ['baz', 'foo', 'bar'],
-        strict: true,
-      });
-    });
-
-    it('errors if used in an incorrect positions', function () {
-      expect(() => {
-        transform("import { hbs } from 'ember-template-imports';\nhbs`hello`;");
-      }).toThrow(
-        /Attempted to use `hbs` to define a template in an unsupported way. Templates defined using this helper must be:/
-      );
-
-      expect(() => {
-        transform("import { hbs } from 'ember-template-imports';\nfunc(hbs`hello`);");
-      }).toThrow(
-        /Attempted to use `hbs` to define a template in an unsupported way. Templates defined using this helper must be:/
-      );
-    });
-
-    it('errors if passed incorrect useTemplateLiteralProposalSemantics version', function () {
-      plugins[0][1].modules['ember-template-imports'].useTemplateLiteralProposalSemantics = true;
-
-      expect(() => {
-        transform(
-          `
-            import { hbs } from 'ember-template-imports';
-
-            const Foo = hbs\`hello\`;
-          `
-        );
-      }).toThrow(
-        /Passed an invalid version for useTemplateLiteralProposalSemantics. This option must be assign a version number. The current valid version numbers are: 1/
-      );
-    });
-  });
-
-  describe('with useTemplateTagProposalSemantics', function () {
-    beforeEach(() => {
-      plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          {
-            precompile() {
-              return precompile.apply(this, arguments);
-            },
-
-            modules: {
-              'ember-template-imports': {
-                export: 'GLIMMER_TEMPLATE',
-                debugName: '<template>',
-                useTemplateTagProposalSemantics: 1,
-              },
-            },
-          },
-        ],
-        '@babel/plugin-proposal-class-properties',
-      ];
-    });
-
-    it('works with templates assigned to variables', function () {
-      let transpiled = transform(
-        `
-          const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { templateOnly as _templateOnly } from \\"@ember/component/template-only\\";
-        import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-
-        const Foo = _templateOnly(\\"foo-bar\\", \\"Foo\\");
-
-        _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), Foo);"
-      `);
-    });
-
-    it('works with templates exported as variables', function () {
-      let transpiled = transform(
-        `
-          export const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { templateOnly as _templateOnly } from \\"@ember/component/template-only\\";
-        import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-        export const Foo = _templateOnly(\\"foo-bar\\", \\"Foo\\");
-
-        _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), Foo);"
-      `);
-    });
-
-    it('works with templates exported as the default', function () {
-      let transpiled = transform(
-        `
-          export default [GLIMMER_TEMPLATE(\`hello\`)];
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-        import { templateOnly as _templateOnly } from \\"@ember/component/template-only\\";
-
-        const _fooBar = _templateOnly(\\"foo-bar\\", \\"_fooBar\\");
-
-        _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), _fooBar);
-
-        export default _fooBar;"
-      `);
-    });
-
-    it('works with templates defined at the top level', function () {
-      let transpiled = transform(
-        `
-          [GLIMMER_TEMPLATE(\`hello\`)];
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-        import { templateOnly as _templateOnly } from \\"@ember/component/template-only\\";
-
-        const _fooBar = _templateOnly(\\"foo-bar\\", \\"_fooBar\\");
-
-        _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), _fooBar);
-
-        export default _fooBar;"
-      `);
-    });
-
-    it('works with templates assigned to classes', function () {
-      let transpiled = transform(
-        `
-          class Foo {
-            [GLIMMER_TEMPLATE(\`hello\`)];
-          }
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-
-        class Foo {}
-
-        _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), Foo);"
-      `);
-    });
-
-    it('works with templates assigned to class expressions', function () {
-      let transpiled = transform(
-        `
-          const Foo = class {
-            [GLIMMER_TEMPLATE(\`hello\`)];
-          }
-        `
-      );
-
-      expect(transpiled).toMatchInlineSnapshot(`
-        "import { setComponentTemplate as _setComponentTemplate } from \\"@ember/component\\";
-
-        const Foo = _setComponentTemplate(Ember.HTMLBars.template(
-        /*
-          hello
-        */
-        \\"precompiled(hello)\\"), class {});"
-      `);
-    });
-
-    it('correctly handles scope', function () {
-      let source = 'hello';
-      transform(
-        `
-          import baz from 'qux';
-
-          let foo = 123;
-          const bar = 456;
-
-          export default [GLIMMER_TEMPLATE(\`${source}\`)];
-        `
-      );
-
-      expect(optionsReceived).toEqual({
-        contents: source,
-        isProduction: undefined,
-        scope: ['baz', 'foo', 'bar'],
-        strict: true,
-      });
-    });
-
-    it('errors if used in an incorrect positions', function () {
-      expect(() => {
-        transform("func([GLIMMER_TEMPLATE('hello')]);");
-      }).toThrow(
-        /Attempted to use `<template>` to define a template in an unsupported way. Templates defined using this syntax must be:/
-      );
-    });
-
-    it('errors if used with template literal syntax', function () {
-      plugins[0][1].modules['ember-template-imports'].useTemplateLiteralProposalSemantics = 1;
-
-      expect(() => {
-        transform("func([GLIMMER_TEMPLATE('hello')]);");
-      }).toThrow(/Cannot use both the template literal and template tag syntax proposals together/);
-    });
-
-    it('errors if passed incorrect useTemplateTagProposalSemantics version', function () {
-      plugins[0][1].modules['ember-template-imports'].useTemplateTagProposalSemantics = true;
-
-      expect(() => {
-        transform(
-          `
-            const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
-          `
-        );
-      }).toThrow(
-        /Passed an invalid version for useTemplateTagProposalSemantics. This option must be assign a version number. The current valid version numbers are: 1/
       );
     });
   });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@babel/plugin-transform-modules-amd": "^7.12.13",
     "@babel/plugin-transform-template-literals": "^7.12.13",
     "@babel/plugin-transform-unicode-escapes": "^7.12.13",
+    "babel-plugin-ember-modules-api-polyfill": "^3.3.0",
     "common-tags": "^1.8.0",
     "ember-source": "^3.25.1",
     "eslint": "^6.8.0",

--- a/src/template-literal-transform.js
+++ b/src/template-literal-transform.js
@@ -1,4 +1,5 @@
 const filePath = require('path');
+const { registerRefs } = require('./util');
 
 module.exports.replaceTemplateLiteralProposal = function (t, path, state, compiled, options) {
   let version = options.useTemplateLiteralProposalSemantics;
@@ -16,42 +17,57 @@ module.exports.replaceTemplateLiteralProposal = function (t, path, state, compil
     let varId = parentPath.node.id;
     let varDeclaration = parentPath.parentPath;
 
-    varDeclaration.insertAfter(
-      t.expressionStatement(
-        t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
-          compiled,
-          varId,
-        ])
-      )
+    registerRefs(
+      varDeclaration.insertAfter(
+        t.expressionStatement(
+          t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
+            compiled,
+            varId,
+          ])
+        )
+      ),
+      (newPath) => [newPath.get('expression.callee'), newPath.get('expression.arguments.0.callee')]
     );
-    path.replaceWith(
-      t.callExpression(state.ensureImport('templateOnly', '@ember/component/template-only'), [
-        t.stringLiteral(filename),
-        t.stringLiteral(varId.name),
-      ])
+
+    registerRefs(
+      path.replaceWith(
+        t.callExpression(state.ensureImport('default', '@ember/component/template-only'), [
+          t.stringLiteral(filename),
+          t.stringLiteral(varId.name),
+        ])
+      ),
+      (newPath) => [newPath.get('callee')]
     );
   } else if (parentPath.node.type === 'ExportDefaultDeclaration') {
     let varId = path.scope.generateUidIdentifier(filename);
 
-    parentPath.insertBefore(
-      t.variableDeclaration('const', [
-        t.variableDeclarator(
-          varId,
-          t.callExpression(state.ensureImport('templateOnly', '@ember/component/template-only'), [
-            t.stringLiteral(filename),
-            t.stringLiteral(varId.name),
-          ])
-        ),
-      ])
-    );
-    parentPath.insertBefore(
-      t.expressionStatement(
-        t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
-          compiled,
-          varId,
+    registerRefs(
+      parentPath.insertBefore(
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            varId,
+            t.callExpression(state.ensureImport('default', '@ember/component/template-only'), [
+              t.stringLiteral(filename),
+              t.stringLiteral(varId.name),
+            ])
+          ),
         ])
-      )
+      ),
+      (newPath) => [newPath.get('declarations.0.init.callee')]
     );
+
+    registerRefs(
+      parentPath.insertBefore(
+        t.expressionStatement(
+          t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
+            compiled,
+            varId,
+          ])
+        )
+      ),
+      (newPath) => [newPath.get('expression.callee'), newPath.get('expression.arguments.0.callee')]
+    );
+
     path.replaceWith(varId);
   } else if (parentPath.node.type === 'ClassProperty') {
     if (parentPath.node.static !== true) {
@@ -69,22 +85,34 @@ module.exports.replaceTemplateLiteralProposal = function (t, path, state, compil
     let classPath = parentPath.parentPath.parentPath;
 
     if (classPath.node.type === 'ClassDeclaration') {
-      classPath.insertAfter(
-        t.expressionStatement(
-          t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
-            compiled,
-            classPath.node.id,
-          ])
-        )
+      registerRefs(
+        classPath.insertAfter(
+          t.expressionStatement(
+            t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
+              compiled,
+              classPath.node.id,
+            ])
+          )
+        ),
+        (newPath) => [
+          newPath.get('expression.callee'),
+          newPath.get('expression.arguments.0.callee'),
+        ]
       );
     } else {
-      classPath.replaceWith(
-        t.expressionStatement(
-          t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
-            compiled,
-            classPath.node,
-          ])
-        )
+      registerRefs(
+        classPath.replaceWith(
+          t.expressionStatement(
+            t.callExpression(state.ensureImport('setComponentTemplate', '@ember/component'), [
+              compiled,
+              classPath.node,
+            ])
+          )
+        ),
+        (newPath) => [
+          newPath.parentPath.get('callee'),
+          newPath.parentPath.get('arguments.0.callee'),
+        ]
       );
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,18 @@
+module.exports.registerRefs = (newPath, getRefPaths) => {
+  if (Array.isArray(newPath)) {
+    if (newPath.length > 1) {
+      throw new Error(
+        'registerRefs is only meant to handle single node transformations. Received more than one path node.'
+      );
+    }
+
+    newPath = newPath[0];
+  }
+
+  let refPaths = getRefPaths(newPath);
+
+  for (let ref of refPaths) {
+    let binding = ref.scope.getBinding(ref.node.name);
+    binding.reference(ref);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,6 +1973,13 @@ babel-plugin-ember-modules-api-polyfill@^3.2.0:
   dependencies:
     ember-rfc176-data "^0.3.16"
 
+babel-plugin-ember-modules-api-polyfill@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.3.0.tgz#dc2599b0615ecb5d952aeadb5e309e5a5d970db6"
+  integrity sha512-ZHeadIPB6prIs6TzAItQl7VO0/Lcy74n47fl4oev4DOgB4iuRfL/CEpGZqm0B/9zODYn4GsE0taCC0HSDWqMYQ==
+  dependencies:
+    ember-rfc176-data "^0.3.16"
+
 babel-plugin-filter-imports@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-4.0.0.tgz#068f8da15236a96a9602c36dc6f4a6eeca70a4f4"


### PR DESCRIPTION
Refactors this plugin to use `createTemplateFactory`, which is the
proper import for defining a template factory in Ember. This will
continue to be transformed by the Ember modules polyfill API, which
should be included after this plugin (and is by `ember-cli-babel`).
A test for that plugin sequencing has been added as well.

Also updated the code to properly register new bindings on the scope.
Previously, new bindings were not found, and so they were not properly
replaced/renamed by subsequent plugin passes.