### PR TITLE
 Add `moduleOverrides` options 

### DIFF
--- a/__tests__/template-literal-tests.js
+++ b/__tests__/template-literal-tests.js
@@ -240,6 +240,42 @@ describe('htmlbars-inline-precompile: useTemplateLiteralProposalSemantics', func
     );
   });
 
+  it('works with glimmer modules', function () {
+    plugins[0][1].moduleOverrides = {
+      '@ember/component/template-only': {
+        default: ['templateOnlyComponent', '@glimmer/core'],
+      },
+      '@ember/template-factory': {
+        createTemplateFactory: ['createTemplateFactory', '@glimmer/core'],
+      },
+      '@ember/component': {
+        setComponentTemplate: ['setComponentTemplate', '@glimmer/core'],
+      },
+    };
+
+    let transpiled = transform(
+      `
+        import { hbs } from 'ember-template-imports';
+
+        const Foo = hbs\`hello\`;
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { templateOnlyComponent as _templateOnlyComponent } from \\"@glimmer/core\\";
+      import { setComponentTemplate as _setComponentTemplate } from \\"@glimmer/core\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@glimmer/core\\";
+
+      const Foo = _templateOnlyComponent(\\"foo-bar\\", \\"Foo\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
   describe('with babel-plugin-ember-modules-api-polyfill', function () {
     beforeEach(() => {
       plugins.push('babel-plugin-ember-modules-api-polyfill');

--- a/__tests__/template-tag-tests.js
+++ b/__tests__/template-tag-tests.js
@@ -311,6 +311,40 @@ describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function
     `);
   });
 
+  it('works with glimmer modules', function () {
+    plugins[0][1].moduleOverrides = {
+      '@ember/component/template-only': {
+        default: ['templateOnlyComponent', '@glimmer/core'],
+      },
+      '@ember/template-factory': {
+        createTemplateFactory: ['createTemplateFactory', '@glimmer/core'],
+      },
+      '@ember/component': {
+        setComponentTemplate: ['setComponentTemplate', '@glimmer/core'],
+      },
+    };
+
+    let transpiled = transform(
+      `
+        const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
+      `
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { templateOnlyComponent as _templateOnlyComponent } from \\"@glimmer/core\\";
+      import { setComponentTemplate as _setComponentTemplate } from \\"@glimmer/core\\";
+      import { createTemplateFactory as _createTemplateFactory } from \\"@glimmer/core\\";
+
+      const Foo = _templateOnlyComponent(\\"foo-bar\\", \\"Foo\\");
+
+      _setComponentTemplate(_createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\"), Foo);"
+    `);
+  });
+
   describe('with babel-plugin-ember-modules-api-polyfill', function () {
     beforeEach(() => {
       plugins.push('babel-plugin-ember-modules-api-polyfill');

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -587,6 +587,36 @@ describe('htmlbars-inline-precompile', function () {
     ).toThrow(/placeholders inside a tagged template string are not supported/);
   });
 
+  it('works with glimmer modules', function () {
+    plugins[0][1].moduleOverrides = {
+      '@ember/component/template-only': {
+        default: ['templateOnlyComponent', '@glimmer/core'],
+      },
+      '@ember/template-factory': {
+        createTemplateFactory: ['createTemplateFactory', '@glimmer/core'],
+      },
+      '@ember/component': {
+        setComponentTemplate: ['setComponentTemplate', '@glimmer/core'],
+      },
+    };
+
+    let transformed = transform(stripIndent`
+      import hbs from 'htmlbars-inline-precompile';
+
+      const template = hbs\`hello\`;
+    `);
+
+    expect(transformed).toEqual(stripIndent`
+      import { createTemplateFactory as _createTemplateFactory } from "@glimmer/core";
+
+      const template = _createTemplateFactory(
+      /*
+        hello
+      */
+      "precompiled(hello)");
+    `);
+  });
+
   describe('caching', function () {
     it('include `baseDir` function for caching', function () {
       expect(HTMLBarsInlinePrecompile.baseDir()).toEqual(path.resolve(__dirname, '..'));

--- a/index.js
+++ b/index.js
@@ -152,12 +152,24 @@ module.exports = function (babel) {
 
       // Find/setup Ember global identifier
       let useEmberModule = Boolean(options.useEmberModule);
+      let moduleOverrides = options.moduleOverrides;
+
       let allAddedImports = {};
 
       state.ensureImport = (exportName, moduleName) => {
         let addedImports = (allAddedImports[moduleName] = allAddedImports[moduleName] || {});
 
         if (addedImports[exportName]) return addedImports[exportName];
+
+        if (moduleOverrides) {
+          let glimmerModule = moduleOverrides[moduleName];
+          let glimmerExport = glimmerModule && glimmerModule[exportName];
+
+          if (glimmerExport) {
+            exportName = glimmerExport[0];
+            moduleName = glimmerExport[1];
+          }
+        }
 
         if (exportName === 'default' && moduleName === 'ember' && !useEmberModule) {
           addedImports[exportName] = t.identifier('Ember');


### PR DESCRIPTION
Adds a global `moduleOverrides` option, which can be used to configure
the import paths that are used for various imports in this transform.
This is meant to be used by Glimmer.js.

Also fixes the import path used for `templateOnly`, which is
meant to be the `default` export of `@ember/component/template-only`