### PR TITLE
Ensure proposal syntaxes work with Ember module API polyfill

### DIFF
--- a/__tests__/template-tag-tests.js
+++ b/__tests__/template-tag-tests.js
@@ -2,6 +2,7 @@
 
 const babel = require('@babel/core');
 const HTMLBarsInlinePrecompile = require('../index');
+const TransformModules = require('@babel/plugin-transform-modules-amd');
 
 describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function () {
   let precompile, plugins, optionsReceived;
@@ -501,6 +502,40 @@ describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function
           hello
         */
         \\"precompiled(hello)\\"), class {});"
+      `);
+    });
+
+    it('works when used alongside modules transform', function () {
+      plugins[0][1].ensureModuleApiPolyfill = true;
+      plugins.push([TransformModules]);
+
+      let transpiled = transform(
+        `
+          const Foo = [GLIMMER_TEMPLATE(\`hello\`)];
+          const Bar = [GLIMMER_TEMPLATE(\`hello\`)];
+        `
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "define([], function () {
+          \\"use strict\\";
+
+          const Foo = Ember._templateOnlyComponent(\\"foo-bar\\", \\"Foo\\");
+
+          Ember._setComponentTemplate(Ember.HTMLBars.template(
+          /*
+            hello
+          */
+          \\"precompiled(hello)\\"), Foo);
+
+          const Bar = Ember._templateOnlyComponent(\\"foo-bar\\", \\"Bar\\");
+
+          Ember._setComponentTemplate(Ember.HTMLBars.template(
+          /*
+            hello
+          */
+          \\"precompiled(hello)\\"), Bar);
+        });"
       `);
     });
   });

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -683,6 +683,28 @@ describe('htmlbars-inline-precompile', function () {
         });"
       `);
     });
+
+    it('works with ensureModuleApiPolyfill', function () {
+      plugins[0][1].ensureModuleApiPolyfill = true;
+
+      precompile = (template) => {
+        return `function() { return "${template}"; }`;
+      };
+
+      let transpiled = transform(
+        "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
+      );
+
+      expect(transpiled).toMatchInlineSnapshot(`
+        "var compiled = Ember.HTMLBars.template(
+        /*
+          hello
+        */
+        function () {
+          return \\"hello\\";
+        });"
+      `);
+    });
   });
 
   describe('with ember-source', function () {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     "lint": "eslint --cache .",
     "test": "jest"
   },
+  "dependencies": {
+    "babel-plugin-ember-modules-api-polyfill": "^3.4.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.12.16",
     "@babel/plugin-proposal-class-properties": "^7.12.13",
     "@babel/plugin-transform-modules-amd": "^7.12.13",
     "@babel/plugin-transform-template-literals": "^7.12.13",
     "@babel/plugin-transform-unicode-escapes": "^7.12.13",
-    "babel-plugin-ember-modules-api-polyfill": "^3.3.0",
     "common-tags": "^1.8.0",
     "ember-source": "^3.25.1",
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,10 +1973,10 @@ babel-plugin-ember-modules-api-polyfill@^3.2.0:
   dependencies:
     ember-rfc176-data "^0.3.16"
 
-babel-plugin-ember-modules-api-polyfill@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.3.0.tgz#dc2599b0615ecb5d952aeadb5e309e5a5d970db6"
-  integrity sha512-ZHeadIPB6prIs6TzAItQl7VO0/Lcy74n47fl4oev4DOgB4iuRfL/CEpGZqm0B/9zODYn4GsE0taCC0HSDWqMYQ==
+babel-plugin-ember-modules-api-polyfill@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.4.0.tgz#3f5e0457e135f8a29b3a8b6910806bb5b524649e"
+  integrity sha512-nVu/LqbZBAup1zLij6xGvQwVLWVk4XYu2fl4vIOUR3S6ukdonMLhKAb0d4QXSzH30Pd7OczVTlPffWbiwahdJw==
   dependencies:
     ember-rfc176-data "^0.3.16"
 


### PR DESCRIPTION
Due to race conditions, some of the imports added by this plugin are not
processed in time by the Ember module API polyfill plugin. They are
instead handled by the AMD loader transform, and then never handled
correctly at all. This PR uses the new JS API exposed from the module
API polyfill plugin to manually process any new import statements.
To enable this, users should pass the `ensureModuleApiPolyfill` option.