### PR TITLE
Default `ensureModuleApiPolyfill` to true

### DIFF
--- a/__tests__/template-literal-tests.js
+++ b/__tests__/template-literal-tests.js
@@ -31,6 +31,8 @@ describe('htmlbars-inline-precompile: useTemplateLiteralProposalSemantics', func
             return precompile.apply(this, arguments);
           },
 
+          ensureModuleApiPolyfill: false,
+
           modules: {
             'ember-template-imports': {
               export: 'hbs',

--- a/__tests__/template-tag-tests.js
+++ b/__tests__/template-tag-tests.js
@@ -31,6 +31,8 @@ describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function
             return precompile.apply(this, arguments);
           },
 
+          ensureModuleApiPolyfill: false,
+
           modules: {
             'TEMPLATE-TAG-MODULE': {
               export: 'GLIMMER_TEMPLATE',

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -35,6 +35,8 @@ describe('htmlbars-inline-precompile', function () {
           precompile() {
             return precompile.apply(this, arguments);
           },
+
+          ensureModuleApiPolyfill: false,
         },
       ],
     ];
@@ -82,6 +84,7 @@ describe('htmlbars-inline-precompile', function () {
             return precompile.apply(this, arguments);
           },
 
+          ensureModuleApiPolyfill: false,
           isProduction: true,
           scope: null,
         },
@@ -133,6 +136,7 @@ describe('htmlbars-inline-precompile', function () {
             return precompile.apply(this, arguments);
           },
 
+          ensureModuleApiPolyfill: false,
           isProduction: true,
         },
       ],
@@ -404,6 +408,8 @@ describe('htmlbars-inline-precompile', function () {
             return precompile.apply(this, arguments);
           },
 
+          ensureModuleApiPolyfill: false,
+
           modules: {
             'ember-cli-htmlbars': 'hbs',
             '@ember/template-compilation': {
@@ -447,6 +453,8 @@ describe('htmlbars-inline-precompile', function () {
             return precompile.apply(this, arguments);
           },
 
+          ensureModuleApiPolyfill: false,
+
           modules: {
             '@ember/template-compilation': {
               export: 'precompileTemplate',
@@ -475,6 +483,8 @@ describe('htmlbars-inline-precompile', function () {
           precompile() {
             return precompile.apply(this, arguments);
           },
+
+          ensureModuleApiPolyfill: false,
 
           modules: {
             'ember-template-imports': {
@@ -736,6 +746,8 @@ describe('htmlbars-inline-precompile', function () {
             precompile() {
               return precompile.apply(this, arguments);
             },
+
+            ensureModuleApiPolyfill: false,
 
             modules: {
               '@ember/template-compilation': {

--- a/index.js
+++ b/index.js
@@ -173,6 +173,9 @@ module.exports = function (babel) {
 
   let visitor = {
     Program(path, state) {
+      state.ensureModuleApiPolyfill =
+        'ensureModuleApiPolyfill' in state.opts ? state.opts.ensureModuleApiPolyfill : true;
+
       if (state.opts.ensureModuleApiPolyfill) {
         // Setup state for the module API polyfill
         setupState(t, path, state);


### PR DESCRIPTION
When we released the refactor to transform to module names instead of
the API polyfill, sometimes those modules would transform correctly,
and sometimes they wouldn't. There appears to be a race condition
between `babel-plugin-ember-modules-api-polyfill`, this plugin, and the
AMD module transform.

This PR updates the default for `ensureModuleApiPolyfill` to true to
make sure we always transpile modules, and do not regress behavior.

Fixes https://github.com/emberjs/ember.js/issues/19425