### PR TITLE
Rename `strict` to `strictMode`

### DIFF
--- a/__tests__/template-literal-tests.js
+++ b/__tests__/template-literal-tests.js
@@ -209,7 +209,7 @@ describe('htmlbars-inline-precompile: useTemplateLiteralProposalSemantics', func
       contents: source,
       isProduction: undefined,
       scope: ['baz', 'foo', 'bar'],
-      strict: true,
+      strictMode: true,
     });
   });
 

--- a/__tests__/template-tag-tests.js
+++ b/__tests__/template-tag-tests.js
@@ -242,7 +242,7 @@ describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function
       contents: source,
       isProduction: undefined,
       scope: ['baz', 'foo', 'bar'],
-      strict: true,
+      strictMode: true,
     });
   });
 

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -148,7 +148,7 @@ describe('htmlbars-inline-precompile', function () {
       contents: source,
       isProduction: true,
       scope: null,
-      strict: false,
+      strictMode: false,
     });
   });
 
@@ -263,7 +263,7 @@ describe('htmlbars-inline-precompile', function () {
       contents: source,
       isProduction: undefined,
       scope: null,
-      strict: false,
+      strictMode: false,
     });
   });
 

--- a/index.js
+++ b/index.js
@@ -376,14 +376,14 @@ module.exports = function (babel) {
 
       let { precompile, isProduction } = state.opts;
       let scope = shouldUseAutomaticScope(options) ? getScope(path.scope) : null;
-      let strict = shouldUseStrictMode(options);
+      let strictMode = shouldUseStrictMode(options);
 
       let emberIdentifier = state.ensureImport('createTemplateFactory', '@ember/template-factory');
 
       replacePath(
         path,
         state,
-        compileTemplate(precompile, template, emberIdentifier, { isProduction, scope, strict }),
+        compileTemplate(precompile, template, emberIdentifier, { isProduction, scope, strictMode }),
         options
       );
     },
@@ -473,7 +473,7 @@ module.exports = function (babel) {
       if (shouldUseStrictMode(options)) {
         // If using the transform semantics, then users are not expected to pass
         // options, so we override any existing strict option
-        compilerOptions.strict = true;
+        compilerOptions.strictMode = true;
       }
 
       replacePath(


### PR DESCRIPTION
We renamed the `strict` option in `ember-cli-htmlbars` to `strictMode`,
to match the precompiler, but we did not rename it in this transform.
This PR updates the option to match the new name.