### PR TITLE
Fix defaulting of `ensureModuleApiPolyfill` to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ module.exports = function (babel) {
 
   let visitor = {
     Program(path, state) {
-      state.ensureModuleApiPolyfill =
+      state.opts.ensureModuleApiPolyfill =
         'ensureModuleApiPolyfill' in state.opts ? state.opts.ensureModuleApiPolyfill : true;
 
       if (state.opts.ensureModuleApiPolyfill) {


### PR DESCRIPTION
The change made in #347 didn't assign back to `state.opts.ensureModuleApiPolyfill` so the default value of `true` is never used.
@pzuraq @rwjblue