### PR TITLE
Avoid sharing list of previously added imports.

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -64,6 +64,36 @@ describe('htmlbars-inline-precompile', function () {
     `);
   });
 
+  it('does not error when transpiling multiple modules with a single plugin config', function () {
+    let transpiled = transform(
+      "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");"
+    `);
+
+    transpiled = transform(
+      "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
+      /*
+        hello
+      */
+      \\"precompiled(hello)\\");"
+    `);
+  });
+
   it('passes options when used as a call expression', function () {
     let source = 'hello';
     transform(`import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('${source}');`);

--- a/index.js
+++ b/index.js
@@ -151,11 +151,9 @@ module.exports = function (babel) {
     }
   }
 
-  let allAddedImports = Object.create(null);
-
   function processModuleApiPolyfill(state) {
-    for (let module in allAddedImports) {
-      let addedImports = allAddedImports[module];
+    for (let module in state.allAddedImports) {
+      let addedImports = state.allAddedImports[module];
 
       for (let addedImport in addedImports) {
         let { path } = addedImports[addedImport];
@@ -187,8 +185,11 @@ module.exports = function (babel) {
       let useEmberModule = Boolean(options.useEmberModule);
       let moduleOverrides = options.moduleOverrides;
 
+      state.allAddedImports = Object.create(null);
+
       state.ensureImport = (exportName, moduleName) => {
-        let addedImports = (allAddedImports[moduleName] = allAddedImports[moduleName] || {});
+        let addedImports = (state.allAddedImports[moduleName] =
+          state.allAddedImports[moduleName] || {});
 
         if (addedImports[exportName]) return addedImports[exportName].id;
 

--- a/src/util.js
+++ b/src/util.js
@@ -13,6 +13,8 @@ module.exports.registerRefs = (newPath, getRefPaths) => {
 
   for (let ref of refPaths) {
     let binding = ref.scope.getBinding(ref.node.name);
-    binding.reference(ref);
+    if (binding !== undefined) {
+      binding.reference(ref);
+    }
   }
 };


### PR DESCRIPTION
The test added here shows the underlying problem, when transpiling multiple files with a shared babel configuration (which is **very normal**), you would end up with failures if any transformation fails (all _future_ transformations would continue to fail):

```
TypeError: /Users/rjackson/src/ember-cli/babel-plugin-htmlbars-inline-precompile/foo-bar.j s: Cannot read property 'reference' of undefined

  14 |   for (let ref of refPaths) {
  15 |     let binding = ref.scope.getBinding(ref.node.name);
> 16 |     binding.reference(ref);
     |             ^
  17 |   }
  18 | };
  19 |

  at reference (src/util.js:16:13)
  at registerRefs (index.js:143:7)
  at PluginPass.replacePath (index.js:383:7)
  at newFn (node_modules/@babel/traverse/lib/visitors.js:175:21)
```

The fundamental issue here is that we shared the list of previously imported modules so that we can make sure their import bindings have been rewritten to use the babel-plugin-ember-modules-api-polyfill transformation. Unfortunately, we tracked that state in the closure state of the babel plugin. That babel plugin closure state is only evaluated / created **once** not once per-file.

This changes things to track the module imports that have been created on the local state (which is reset properly per "transpilation attempt").
