### PR TITLE
[BUGFIX] Use a unique identifier for each reference

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -555,6 +555,30 @@ describe('htmlbars-inline-precompile', function () {
     `);
   });
 
+  it('works properly when used along with modules transform multiple times', function () {
+    plugins.push([TransformModules]);
+    let transformed = transform(
+      "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;\nvar otherCompiled = hbs`hello`;"
+    );
+
+    expect(transformed).toMatchInlineSnapshot(`
+      "define([\\"@ember/template-factory\\"], function (_templateFactory) {
+        \\"use strict\\";
+
+        var compiled = (0, _templateFactory.createTemplateFactory)(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\");
+        var otherCompiled = (0, _templateFactory.createTemplateFactory)(
+        /*
+          hello
+        */
+        \\"precompiled(hello)\\");
+      });"
+    `);
+  });
+
   it('works properly when used after modules transform', function () {
     plugins.unshift([TransformModules]);
     let transformed = transform(

--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ module.exports = function (babel) {
         let addedImports = (state.allAddedImports[moduleName] =
           state.allAddedImports[moduleName] || {});
 
-        if (addedImports[exportName]) return addedImports[exportName].id;
+        if (addedImports[exportName]) return t.identifier(addedImports[exportName].id.name);
 
         if (moduleOverrides) {
           let glimmerModule = moduleOverrides[moduleName];
@@ -205,6 +205,7 @@ module.exports = function (babel) {
 
         if (exportName === 'default' && moduleName === 'ember' && !useEmberModule) {
           addedImports[exportName] = { id: t.identifier('Ember') };
+
           return addedImports[exportName].id;
         }
 
@@ -218,7 +219,7 @@ module.exports = function (babel) {
           let importSpecifier = preexistingImportDeclaration.get('specifiers').find(({ node }) => {
             return exportName === 'default'
               ? t.isImportDefaultSpecifier(node)
-              : node.imported.name === exportName;
+              : node.imported && node.imported.name === exportName;
           });
 
           if (importSpecifier) {
@@ -246,7 +247,7 @@ module.exports = function (babel) {
           };
         }
 
-        return addedImports[exportName].id;
+        return t.identifier(addedImports[exportName].id.name);
       };
 
       // Setup other module options and create cache for values


### PR DESCRIPTION
Currently we reuse the same identifier for each reference to an imported
value. Apparently this is not the way the scope system is meant to work,
and instead we should be creating a new id node for each reference.