### PR TITLE
Adds a `templateCompilerPath` option

### DIFF
--- a/__tests__/mock-precompile.js
+++ b/__tests__/mock-precompile.js
@@ -1,0 +1,5 @@
+module.exports = {
+  precompile(value) {
+    return `precompiledFromPath(${value})`;
+  },
+};

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -64,6 +64,24 @@ describe('htmlbars-inline-precompile', function () {
     `);
   });
 
+  it('supports compilation with templateCompilerPath', function () {
+    plugins[0][1].templateCompilerPath = require.resolve('./mock-precompile');
+
+    let transpiled = transform(
+      "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
+    );
+
+    expect(transpiled).toMatchInlineSnapshot(`
+      "import { createTemplateFactory as _createTemplateFactory } from \\"@ember/template-factory\\";
+
+      var compiled = _createTemplateFactory(
+      /*
+        hello
+      */
+      precompiledFromPath(hello));"
+    `);
+  });
+
   it('does not error when transpiling multiple modules with a single plugin config', function () {
     let transpiled = transform(
       "import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;"
@@ -822,7 +840,7 @@ describe('htmlbars-inline-precompile', function () {
 
       expect(optionsReceived).toEqual({
         contents: source,
-        scope: ['foo', 'bar'],
+        locals: ['foo', 'bar'],
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint --cache .",
     "test": "jest"
   },
+  "jest": {
+    "testPathIgnorePatterns": ["mock-precompile"]
+  },
   "dependencies": {
     "babel-plugin-ember-modules-api-polyfill": "^3.4.0"
   },


### PR DESCRIPTION
This adds a `templateCompilerPath` option so the plugin can require the
template compiler directly. Also updates the transform to rename `scope`
to `locals`, so that it matches the public API of the template compiler.