### PR TITLE
[BUGFIX] Ensure locals are used instead of scope everywhere

### DIFF
--- a/__tests__/template-literal-tests.js
+++ b/__tests__/template-literal-tests.js
@@ -208,7 +208,7 @@ describe('htmlbars-inline-precompile: useTemplateLiteralProposalSemantics', func
     expect(optionsReceived).toEqual({
       contents: source,
       isProduction: undefined,
-      scope: ['baz', 'foo', 'bar'],
+      locals: ['baz', 'foo', 'bar'],
       strictMode: true,
     });
   });

--- a/__tests__/template-tag-tests.js
+++ b/__tests__/template-tag-tests.js
@@ -241,7 +241,7 @@ describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function
     expect(optionsReceived).toEqual({
       contents: source,
       isProduction: undefined,
-      scope: ['baz', 'foo', 'bar'],
+      locals: ['baz', 'foo', 'bar'],
       strictMode: true,
     });
   });

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -134,7 +134,7 @@ describe('htmlbars-inline-precompile', function () {
 
           ensureModuleApiPolyfill: false,
           isProduction: true,
-          scope: null,
+          locals: null,
         },
       ],
     ];
@@ -195,7 +195,7 @@ describe('htmlbars-inline-precompile', function () {
     expect(optionsReceived).toEqual({
       contents: source,
       isProduction: true,
-      scope: null,
+      locals: null,
       strictMode: false,
     });
   });
@@ -310,7 +310,7 @@ describe('htmlbars-inline-precompile', function () {
     expect(optionsReceived).toEqual({
       contents: source,
       isProduction: undefined,
-      scope: null,
+      locals: null,
       strictMode: false,
     });
   });

--- a/index.js
+++ b/index.js
@@ -383,7 +383,7 @@ module.exports = function (babel) {
       let template = path.node.quasi.quasis.map((quasi) => quasi.value.cooked).join('');
 
       let { isProduction } = state.opts;
-      let scope = shouldUseAutomaticScope(options) ? getScope(path.scope) : null;
+      let locals = shouldUseAutomaticScope(options) ? getScope(path.scope) : null;
       let strictMode = shouldUseStrictMode(options);
 
       let emberIdentifier = state.ensureImport('createTemplateFactory', '@ember/template-factory');
@@ -391,7 +391,11 @@ module.exports = function (babel) {
       replacePath(
         path,
         state,
-        compileTemplate(precompile, template, emberIdentifier, { isProduction, scope, strictMode }),
+        compileTemplate(precompile, template, emberIdentifier, {
+          isProduction,
+          locals,
+          strictMode,
+        }),
         options
       );
     },
@@ -475,7 +479,7 @@ module.exports = function (babel) {
       if (shouldUseAutomaticScope(options)) {
         // If using the transform semantics, then users are not expected to pass
         // options, so we override any existing scope
-        compilerOptions.scope = getScope(path.scope);
+        compilerOptions.locals = getScope(path.scope);
       }
 
       if (shouldUseStrictMode(options)) {


### PR DESCRIPTION
I missed a couple locations where `locals` are used, and did not catch
it until recently.