### PR TITLE
Add preprocessEmbeddedTemplates function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2017,
   },
@@ -12,6 +13,7 @@ module.exports = {
   env: {
     node: true,
   },
+  ignorePatterns: ['dist/**/*.js'],
   rules: { },
   overrides: [
     // test files
@@ -25,6 +27,43 @@ module.exports = {
       rules: {
         'node/no-unpublished-require': 'off',
       },
+    },
+    {
+      parserOptions: {
+        ecmaVersion: 2020,
+      },
+      files: ['**/*.ts'],
+      plugins: ['@typescript-eslint'],
+      extends: [
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended',
+      ],
+      rules: {
+        'node/no-unsupported-features/es-syntax': ['error', {
+          'ignores': ['modules']
+        }],
+        'node/no-missing-import': 'off',
+
+        '@typescript-eslint/no-explicit-any': 'error',
+        '@typescript-eslint/explicit-function-return-type': 'error',
+        '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+
+        // We should try to remove this eventually
+        '@typescript-eslint/explicit-function-return-type': 'off',
+
+        '@typescript-eslint/ban-types': ['error', {
+          types: {
+            // we currently use `object` as "valid WeakMap key" in a lot of APIs
+            object: false,
+          }
+        }],
+
+        // disabling this one because of DEBUG APIs, if we ever find a better
+        // way to suport those we should re-enable it
+        '@typescript-eslint/no-non-null-assertion': 'off',
+
+        '@typescript-eslint/no-use-before-define': 'off',
+      }
     },
   ],
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 coverage
 node_modules
 /.eslintcache
+/dist
+yarn-error.log

--- a/__tests__/preprocess-embedded-templates-tests.js
+++ b/__tests__/preprocess-embedded-templates-tests.js
@@ -1,0 +1,924 @@
+const { preprocessEmbeddedTemplates } = require('../index');
+const { stripIndent } = require('common-tags');
+
+const getTemplateLocalsRequirePath = require.resolve('@glimmer/syntax');
+
+const TEMPLATE_TAG_CONFIG = {
+  getTemplateLocalsRequirePath,
+  getTemplateLocalsExportPath: 'getTemplateLocals',
+
+  templateTag: 'template',
+  templateTagReplacement: 'GLIMMER_TEMPLATE',
+
+  relativePath: '/foo/bar.gjs',
+  includeSourceMaps: false,
+  includeTemplateTokens: true,
+};
+
+const TEMPLATE_LITERAL_CONFIG = {
+  getTemplateLocalsRequirePath,
+  getTemplateLocalsExportPath: 'getTemplateLocals',
+
+  importIdentifier: 'hbs',
+  importPath: 'ember-template-imports',
+
+  relativePath: '/foo/bar.js',
+  includeSourceMaps: false,
+  includeTemplateTokens: true,
+};
+
+describe('htmlbars-inline-precompile: preprocessEmbeddedTemplates', () => {
+  describe('template tag', () => {
+    it('works with basic templates', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          <template>Hello, world!</template>
+        `,
+        TEMPLATE_TAG_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "[GLIMMER_TEMPLATE(\`Hello, world!\`)]",
+          "replacements": Array [
+            Object {
+              "index": 0,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 1,
+              "originalLine": 1,
+              "type": "start",
+            },
+            Object {
+              "index": 23,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 24,
+              "originalLine": 1,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('works with templates assigned to variables', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          const Foo = <template>Hello, world!</template>
+        `,
+        TEMPLATE_TAG_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "const Foo = [GLIMMER_TEMPLATE(\`Hello, world!\`)]",
+          "replacements": Array [
+            Object {
+              "index": 12,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 13,
+              "originalLine": 1,
+              "type": "start",
+            },
+            Object {
+              "index": 35,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 36,
+              "originalLine": 1,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('works with nested templates', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          <template>
+            <template>Hello, world!</template>
+          </template>
+        `,
+        TEMPLATE_TAG_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "[GLIMMER_TEMPLATE(\`
+          <template>Hello, world!</template>
+        \`)]",
+          "replacements": Array [
+            Object {
+              "index": 0,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 1,
+              "originalLine": 1,
+              "type": "start",
+            },
+            Object {
+              "index": 48,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 1,
+              "originalLine": 3,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('it does not process templates in strings', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          const Foo = <template></template>
+          const foo = "<template></template>";
+          const Bar = <template></template>
+          const bar = '<template></template>';
+          const Baz = <template></template>
+          const baz = \`
+            <template>
+              \${'<template></template>'}
+              \${expr({ foo: '<template></template>' })}
+              \${nested(\`
+                <template></template>
+              \`)}
+            </template>
+          \`;
+
+          <template></template>
+          const regex = /<template><\/template>/;
+        `,
+        TEMPLATE_TAG_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "const Foo = [GLIMMER_TEMPLATE(\`\`)]
+        const foo = \\"<template></template>\\";
+        const Bar = [GLIMMER_TEMPLATE(\`\`)]
+        const bar = '<template></template>';
+        const Baz = [GLIMMER_TEMPLATE(\`\`)]
+        const baz = \`
+          <template>
+            \${'<template></template>'}
+            \${expr({ foo: '<template></template>' })}
+            \${nested(\`
+              <template></template>
+            \`)}
+          </template>
+        \`;
+
+        [GLIMMER_TEMPLATE(\`\`)]
+        const regex = /<template></template>/;",
+          "replacements": Array [
+            Object {
+              "index": 12,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 13,
+              "originalLine": 1,
+              "type": "start",
+            },
+            Object {
+              "index": 22,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 23,
+              "originalLine": 1,
+              "type": "end",
+            },
+            Object {
+              "index": 83,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 13,
+              "originalLine": 3,
+              "type": "start",
+            },
+            Object {
+              "index": 93,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 23,
+              "originalLine": 3,
+              "type": "end",
+            },
+            Object {
+              "index": 154,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 13,
+              "originalLine": 5,
+              "type": "start",
+            },
+            Object {
+              "index": 164,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 23,
+              "originalLine": 5,
+              "type": "end",
+            },
+            Object {
+              "index": 349,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 1,
+              "originalLine": 16,
+              "type": "start",
+            },
+            Object {
+              "index": 359,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 11,
+              "originalLine": 16,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('works with class templates', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          class Foo {
+            <template>Hello, world!</template>
+          }
+        `,
+        TEMPLATE_TAG_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "class Foo {
+          [GLIMMER_TEMPLATE(\`Hello, world!\`)]
+        }",
+          "replacements": Array [
+            Object {
+              "index": 14,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 3,
+              "originalLine": 2,
+              "type": "start",
+            },
+            Object {
+              "index": 37,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 26,
+              "originalLine": 2,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('works with basic multi-line aoeu templates', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          class Foo {
+            <template>
+              Hello, world!
+            </template>
+          }
+        `,
+        TEMPLATE_TAG_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "class Foo {
+          [GLIMMER_TEMPLATE(\`
+            Hello, world!
+          \`)]
+        }",
+          "replacements": Array [
+            Object {
+              "index": 14,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 3,
+              "originalLine": 2,
+              "type": "start",
+            },
+            Object {
+              "index": 45,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 3,
+              "originalLine": 4,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('exposes template identifiers', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          class Foo {
+            <template>
+              <Component/>
+
+              <ComponentWithYield>
+                <:main></:main>
+              </ComponentWithYield>
+
+              {{#if globalValue}}
+                {{globalHelper 123}}
+              {{/if}}
+
+              {{#if this.localValue}}
+                {{this.localHelper 123}}
+              {{/if}}
+
+              {{@arg}}
+              <@argComponent />
+
+              {{#this.dynamicBlockComponent}}
+              {{/this.dynamicBlockComponent}}
+
+              <this.dynamicAngleComponent>
+              </this.dynamicAngleComponent>
+            </template>
+          }
+        `,
+        TEMPLATE_TAG_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "class Foo {
+          [GLIMMER_TEMPLATE(\`
+            <Component/>
+
+            <ComponentWithYield>
+              <:main></:main>
+            </ComponentWithYield>
+
+            {{#if globalValue}}
+              {{globalHelper 123}}
+            {{/if}}
+
+            {{#if this.localValue}}
+              {{this.localHelper 123}}
+            {{/if}}
+
+            {{@arg}}
+            <@argComponent />
+
+            {{#this.dynamicBlockComponent}}
+            {{/this.dynamicBlockComponent}}
+
+            <this.dynamicAngleComponent>
+            </this.dynamicAngleComponent>
+          \`, { scope() { return {Component,ComponentWithYield,globalValue,globalHelper}; } })]
+        }",
+          "replacements": Array [
+            Object {
+              "index": 14,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 3,
+              "originalLine": 2,
+              "type": "start",
+            },
+            Object {
+              "index": 431,
+              "newLength": 84,
+              "oldLength": 11,
+              "originalCol": 3,
+              "originalLine": 25,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('throws if template args are detected', () => {
+      expect(() => {
+        preprocessEmbeddedTemplates(
+          stripIndent`
+            class Foo {
+              <template @foo="bar">
+                Hello, world!
+              </template>
+            }
+          `,
+          TEMPLATE_TAG_CONFIG
+        );
+      }).toThrow(/embedded template preprocessing currently does not support passing arguments/);
+    });
+
+    it('can include sourcemaps', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          class Foo {
+            <template>Hello, world!</template>
+          }
+        `,
+        Object.assign({}, TEMPLATE_TAG_CONFIG, { includeSourceMaps: true })
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "class Foo {
+          [GLIMMER_TEMPLATE(\`Hello, world!\`)]
+        }
+        //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYmFyLmpzIiwic291cmNlcyI6WyJiYXIuZ2pzIl0sInNvdXJjZXNDb250ZW50IjpbImNsYXNzIEZvbyB7XG4gIDx0ZW1wbGF0ZT5IZWxsbywgd29ybGQhPC90ZW1wbGF0ZT5cbn0iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO0FBQ1gsQ0FBQyxDQUFDLG1CQUFVLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsR0FBVztBQUNwQyJ9",
+          "replacements": Array [
+            Object {
+              "index": 14,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 3,
+              "originalLine": 2,
+              "type": "start",
+            },
+            Object {
+              "index": 37,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 26,
+              "originalLine": 2,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+  });
+
+  describe('template literal', () => {
+    it('works with basic templates', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          export default hbs\`Hello, world!\`;
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        export default hbs(\`Hello, world!\`);",
+          "replacements": Array [
+            Object {
+              "index": 62,
+              "newLength": 5,
+              "oldLength": 4,
+              "originalCol": 16,
+              "originalLine": 3,
+              "type": "start",
+            },
+            Object {
+              "index": 79,
+              "newLength": 2,
+              "oldLength": 1,
+              "originalCol": 33,
+              "originalLine": 3,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('works with templates assigned to variables', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          const Foo = hbs\`Hello, world!\`;
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        const Foo = hbs(\`Hello, world!\`);",
+          "replacements": Array [
+            Object {
+              "index": 59,
+              "newLength": 5,
+              "oldLength": 4,
+              "originalCol": 13,
+              "originalLine": 3,
+              "type": "start",
+            },
+            Object {
+              "index": 76,
+              "newLength": 2,
+              "oldLength": 1,
+              "originalCol": 30,
+              "originalLine": 3,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('works with class templates', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`Hello, world!\`;
+          }
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs(\`Hello, world!\`);
+        }",
+          "replacements": Array [
+            Object {
+              "index": 79,
+              "newLength": 5,
+              "oldLength": 4,
+              "originalCol": 21,
+              "originalLine": 4,
+              "type": "start",
+            },
+            Object {
+              "index": 96,
+              "newLength": 2,
+              "oldLength": 1,
+              "originalCol": 38,
+              "originalLine": 4,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('works with basic multi-line templates', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`
+              Hello, world!
+            \`;
+          }
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs(\`
+            Hello, world!
+          \`);
+        }",
+          "replacements": Array [
+            Object {
+              "index": 79,
+              "newLength": 5,
+              "oldLength": 4,
+              "originalCol": 21,
+              "originalLine": 4,
+              "type": "start",
+            },
+            Object {
+              "index": 104,
+              "newLength": 2,
+              "oldLength": 1,
+              "originalCol": 3,
+              "originalLine": 6,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('exposes template identifiers', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`
+              <Component/>
+
+              <ComponentWithYield>
+                <:main></:main>
+              </ComponentWithYield>
+
+              {{#if globalValue}}
+                {{globalHelper 123}}
+              {{/if}}
+
+              {{#if this.localValue}}
+                {{this.localHelper 123}}
+              {{/if}}
+
+              {{@arg}}
+              <@argComponent />
+
+              {{#this.dynamicBlockComponent}}
+              {{/this.dynamicBlockComponent}}
+
+              <this.dynamicAngleComponent>
+              </this.dynamicAngleComponent>
+            \`;
+          }
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs(\`
+            <Component/>
+
+            <ComponentWithYield>
+              <:main></:main>
+            </ComponentWithYield>
+
+            {{#if globalValue}}
+              {{globalHelper 123}}
+            {{/if}}
+
+            {{#if this.localValue}}
+              {{this.localHelper 123}}
+            {{/if}}
+
+            {{@arg}}
+            <@argComponent />
+
+            {{#this.dynamicBlockComponent}}
+            {{/this.dynamicBlockComponent}}
+
+            <this.dynamicAngleComponent>
+            </this.dynamicAngleComponent>
+          \`, { scope() { return {Component,ComponentWithYield,globalValue,globalHelper}; } });
+        }",
+          "replacements": Array [
+            Object {
+              "index": 79,
+              "newLength": 5,
+              "oldLength": 4,
+              "originalCol": 21,
+              "originalLine": 4,
+              "type": "start",
+            },
+            Object {
+              "index": 490,
+              "newLength": 83,
+              "oldLength": 1,
+              "originalCol": 3,
+              "originalLine": 27,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('does not preprocess templates without correct import', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { otherHbs as hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`Hello, world!\`;
+          }
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { otherHbs as hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs\`Hello, world!\`;
+        }",
+          "replacements": Array [],
+        }
+      `);
+    });
+
+    it('does preprocess templates based on import name', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs as otherHbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = otherHbs\`Hello, world!\`;
+          }
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs as otherHbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = otherHbs(\`Hello, world!\`);
+        }",
+          "replacements": Array [
+            Object {
+              "index": 91,
+              "newLength": 10,
+              "oldLength": 9,
+              "originalCol": 21,
+              "originalLine": 4,
+              "type": "start",
+            },
+            Object {
+              "index": 113,
+              "newLength": 2,
+              "oldLength": 1,
+              "originalCol": 43,
+              "originalLine": 4,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('does not preprocess templates that contain dynamic segments', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`\${'Dynamic!'}\`;
+          }
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs\`\${'Dynamic!'}\`;
+        }",
+          "replacements": Array [],
+        }
+      `);
+    });
+
+    it('does preprocess templates that contain escaped dynamic segments', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`\\\${'Actually not dynamic!'}\`;
+          }
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs(\`\\\\\${'Actually not dynamic!'}\`);
+        }",
+          "replacements": Array [
+            Object {
+              "index": 79,
+              "newLength": 5,
+              "oldLength": 4,
+              "originalCol": 21,
+              "originalLine": 4,
+              "type": "start",
+            },
+            Object {
+              "index": 110,
+              "newLength": 2,
+              "oldLength": 1,
+              "originalCol": 52,
+              "originalLine": 4,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('correctly preprocesses templates that contain escaped backticks', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`\\\`\`;
+          }
+        `,
+        TEMPLATE_LITERAL_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs(\`\\\\\`\`);
+        }",
+          "replacements": Array [
+            Object {
+              "index": 79,
+              "newLength": 5,
+              "oldLength": 4,
+              "originalCol": 21,
+              "originalLine": 4,
+              "type": "start",
+            },
+            Object {
+              "index": 85,
+              "newLength": 2,
+              "oldLength": 1,
+              "originalCol": 27,
+              "originalLine": 4,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('can include sourcemaps', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          import { hbs } from 'ember-template-imports';
+
+          class Foo {
+            static template = hbs\`Hello, world!\`
+          }
+        `,
+        Object.assign({}, TEMPLATE_LITERAL_CONFIG, { includeSourceMaps: true })
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "import { hbs } from 'ember-template-imports';
+
+        class Foo {
+          static template = hbs(\`Hello, world!\`)
+        }
+        //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYmFyLmpzIiwic291cmNlcyI6WyJiYXIuanMiXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgaGJzIH0gZnJvbSAnZW1iZXItdGVtcGxhdGUtaW1wb3J0cyc7XG5cbmNsYXNzIEZvbyB7XG4gIHN0YXRpYyB0ZW1wbGF0ZSA9IGhic2BIZWxsbywgd29ybGQhYFxufSJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztBQUM3QztBQUNBLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztBQUNYLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxLQUFJLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBQztBQUN0QyJ9",
+          "replacements": Array [
+            Object {
+              "index": 79,
+              "newLength": 5,
+              "oldLength": 4,
+              "originalCol": 21,
+              "originalLine": 4,
+              "type": "start",
+            },
+            Object {
+              "index": 96,
+              "newLength": 2,
+              "oldLength": 1,
+              "originalCol": 38,
+              "originalLine": 4,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+  });
+});

--- a/index.js
+++ b/index.js
@@ -543,3 +543,5 @@ module.exports._parallelBabel = {
 module.exports.baseDir = function () {
   return __dirname;
 };
+
+module.exports.preprocessEmbeddedTemplates = require('./dist/preprocess-embedded-templates').default;

--- a/local-types.d.ts
+++ b/local-types.d.ts
@@ -1,0 +1,11 @@
+declare module 'parse-static-imports' {
+  export interface Import {
+    moduleName: string;
+    starImport: string;
+    namedImports: { name: string; alias: string }[];
+    defaultImport: string;
+    sideEffectOnly: boolean;
+  }
+
+  export default function parseStaticImports(code: string): Import[];
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "license": "MIT",
   "author": "Clemens Müller <cmueller.418@gmail.com>",
   "scripts": {
-    "lint": "eslint --cache .",
+    "prepare": "tsc",
+    "build": "tsc",
+    "pretest": "tsc",
+    "lint": "tsc && eslint --cache .",
     "test": "jest"
   },
   "jest": {
@@ -14,8 +17,17 @@
       "mock-precompile"
     ]
   },
+  "files": [
+    "index.js",
+    "src/**/*.js",
+    "dist/**/*.js"
+  ],
   "dependencies": {
-    "babel-plugin-ember-modules-api-polyfill": "^3.4.0"
+    "babel-plugin-ember-modules-api-polyfill": "^3.4.0",
+    "line-column": "^1.0.2",
+    "magic-string": "^0.25.7",
+    "parse-static-imports": "^1.1.0",
+    "string.prototype.matchall": "^4.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",
@@ -23,6 +35,11 @@
     "@babel/plugin-transform-modules-amd": "^7.13.0",
     "@babel/plugin-transform-template-literals": "^7.13.0",
     "@babel/plugin-transform-unicode-escapes": "^7.12.13",
+    "@glimmer/syntax": "^0.77.5",
+    "@types/line-column": "^1.0.0",
+    "@types/string.prototype.matchall": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "^4.18.0",
+    "@typescript-eslint/parser": "^4.18.0",
     "common-tags": "^1.8.0",
     "ember-source": "^3.25.3",
     "eslint": "^6.8.0",
@@ -32,7 +49,8 @@
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "release-it": "^14.4.1",
-    "release-it-lerna-changelog": "^3.1.0"
+    "release-it-lerna-changelog": "^3.1.0",
+    "typescript": "^4.2.3"
   },
   "engines": {
     "node": "10.* || >= 12.*"

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,7 @@
+export function expect<T>(value: T | null | undefined, message: string): T {
+  if (value === undefined || value === null) {
+    throw new Error(`LIBRARY BUG: ${message}`);
+  }
+
+  return value;
+}

--- a/src/parse-templates.ts
+++ b/src/parse-templates.ts
@@ -1,0 +1,247 @@
+import matchAll from 'string.prototype.matchall';
+import { expect } from './debug';
+
+export type TemplateMatch = TemplateTagMatch | TemplateLiteralMatch;
+
+export interface TemplateTagMatch {
+  type: 'template-tag';
+  start: RegExpMatchArray;
+  end: RegExpMatchArray;
+}
+
+export interface TemplateLiteralMatch {
+  type: 'template-literal';
+  tagName: string;
+  start: RegExpMatchArray;
+  end: RegExpMatchArray;
+}
+
+const escapeChar = '\\';
+const stringOrRegexDelimiter = /['"/]/;
+
+const templateLiteralStart = /([$a-zA-Z_][0-9a-zA-Z_$]*)?`/;
+const templateLiteralEnd = /`/;
+
+const dynamicSegmentStart = /\${/;
+const blockStart = /{/;
+const dynamicSegmentEnd = /}/;
+
+function isEscaped(template: string, _offset: number | undefined) {
+  let offset = expect(_offset, 'Expected an index to check escaping');
+
+  let count = 0;
+
+  while (template[offset - 1] === escapeChar) {
+    count++;
+    offset--;
+  }
+
+  return count % 2 === 1;
+}
+
+/**
+ * Parses a template to find all possible valid matches for an embedded template.
+ * Supported syntaxes are template literals:
+ *
+ *   hbs`Hello, world!`
+ *
+ * And template tags
+ *
+ *   <template></template>
+ *
+ * The parser excludes any values found within strings recursively, and also
+ * excludes any string literals with dynamic segments (e.g `${}`) since these
+ * cannot be valid templates.
+ *
+ * @param template The template to parse
+ * @param relativePath Relative file path for the template (for errors)
+ * @param templateTag Optional template tag if parsing template tags is enabled
+ * @returns
+ */
+export function parseTemplates(
+  template: string,
+  relativePath: string,
+  templateTag?: string
+): TemplateMatch[] {
+  const results: TemplateMatch[] = [];
+
+  const templateTagStart = new RegExp(`<${templateTag}[^<]*>`);
+  const templateTagEnd = new RegExp(`</${templateTag}>`);
+  const argumentsMatchRegex = new RegExp(`<${templateTag}[^<]*\\S[^<]*>`);
+
+  const allTokens = new RegExp(
+    `["'\`/]|([$a-zA-Z_][0-9a-zA-Z_$]*)\`|\\\${|{|}|<${templateTag}[^<]*?>|<\\/${templateTag}>`,
+    'g'
+  );
+
+  const tokens = Array.from(matchAll(template, allTokens));
+
+  while (tokens.length > 0) {
+    const currentToken = tokens.shift()!;
+
+    parseToken(results, template, currentToken, tokens, true);
+  }
+
+  /**
+   * Parse the current token. If top level, then template tags can be parsed.
+   * Else, we are nested within a dynamic segment, which is currently unsupported.
+   */
+  function parseToken(
+    results: TemplateMatch[],
+    template: string,
+    token: RegExpMatchArray,
+    tokens: RegExpMatchArray[],
+    isTopLevel = false
+  ) {
+    if (token[0].match(stringOrRegexDelimiter)) {
+      parseStringOrRegex(results, template, token, tokens);
+    }
+
+    if (token[0].match(templateLiteralStart)) {
+      parseTemplateLiteral(results, template, token, tokens, isTopLevel);
+    }
+
+    if (
+      isTopLevel &&
+      templateTag !== undefined &&
+      templateTagStart &&
+      token[0].match(templateTagStart)
+    ) {
+      parseTemplateTag(results, template, token, tokens);
+    }
+  }
+
+  /**
+   * Parse a string or a regex. All tokens within a string or regex are ignored
+   * since there are no dynamic segments within these.
+   */
+  function parseStringOrRegex(
+    _results: TemplateMatch[],
+    template: string,
+    startToken: RegExpMatchArray,
+    tokens: RegExpMatchArray[]
+  ) {
+    while (tokens.length > 0) {
+      const currentToken = expect(tokens.shift(), 'expected token');
+
+      if (currentToken[0] === startToken[0] && !isEscaped(template, currentToken.index)) {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Parse a template literal. If a dynamic segment is found, enters the dynamic
+   * segment and parses it recursively. If no dynamic segments are found and the
+   * literal is top level (e.g. not nested within a dynamic segment) and has a
+   * tag, pushes it into the list of results.
+   */
+  function parseTemplateLiteral(
+    results: TemplateMatch[],
+    template: string,
+    startToken: RegExpMatchArray,
+    tokens: RegExpMatchArray[],
+    isTopLevel = false
+  ) {
+    let hasDynamicSegment = false;
+
+    while (tokens.length > 0) {
+      let currentToken = expect(tokens.shift(), 'expected token');
+
+      if (isEscaped(template, currentToken.index)) continue;
+
+      if (currentToken[0].match(dynamicSegmentStart)) {
+        hasDynamicSegment = true;
+
+        parseDynamicSegment(results, template, currentToken, tokens);
+      } else if (currentToken[0].match(templateLiteralEnd)) {
+        if (isTopLevel && !hasDynamicSegment && startToken[1]?.length > 0) {
+          // Handle the case where a tag-like was matched, e.g. hbs`hello`
+          if (currentToken[0].length > 1) {
+            const tokenStr = currentToken[0];
+            const index = expect(currentToken.index, 'expected index');
+
+            currentToken = ['`'];
+            currentToken.index = index + tokenStr.length - 1;
+          }
+
+          results.push({
+            type: 'template-literal',
+            tagName: startToken[1],
+            start: startToken,
+            end: currentToken,
+          });
+        }
+
+        return;
+      }
+    }
+  }
+
+  /**
+   * Parses a dynamic segment within a template literal. Continues parsing until
+   * the dynamic segment has been exited, ignoring all tokens within it.
+   * Accounts for nested block statements, strings, and template literals.
+   */
+  function parseDynamicSegment(
+    results: TemplateMatch[],
+    template: string,
+    _startToken: RegExpMatchArray,
+    tokens: RegExpMatchArray[]
+  ) {
+    let stack = 1;
+
+    while (tokens.length > 0) {
+      const currentToken = expect(tokens.shift(), 'expected token');
+
+      if (currentToken[0].match(blockStart)) {
+        stack++;
+      } else if (currentToken[0].match(dynamicSegmentEnd)) {
+        stack--;
+      } else {
+        parseToken(results, template, currentToken, tokens);
+      }
+
+      if (stack === 0) {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Parses a template tag. Continues parsing until the template tag has closed,
+   * accounting for nested template tags.
+   */
+  function parseTemplateTag(
+    results: TemplateMatch[],
+    _template: string,
+    startToken: RegExpMatchArray,
+    tokens: RegExpMatchArray[]
+  ) {
+    let stack = 1;
+
+    if (argumentsMatchRegex && startToken[0].match(argumentsMatchRegex)) {
+      throw new Error(
+        `embedded template preprocessing currently does not support passing arguments, found args in: ${relativePath}`
+      );
+    }
+
+    while (tokens.length > 0) {
+      const currentToken = expect(tokens.shift(), 'expected token');
+
+      if (currentToken[0].match(templateTagStart)) {
+        stack++;
+      } else if (currentToken[0].match(templateTagEnd)) {
+        stack--;
+      }
+
+      if (stack === 0) {
+        results.push({ type: 'template-tag', start: startToken, end: currentToken });
+
+        return;
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/preprocess-embedded-templates.ts
+++ b/src/preprocess-embedded-templates.ts
@@ -1,0 +1,240 @@
+import MagicString from 'magic-string';
+import path from 'path';
+import parseStaticImports from 'parse-static-imports';
+import lineColumn from 'line-column';
+import { expect } from './debug';
+import { parseTemplates, TemplateMatch } from './parse-templates';
+
+interface PreprocessOptions {
+  getTemplateLocalsRequirePath: string;
+  getTemplateLocalsExportPath: string;
+
+  importIdentifier?: string;
+  importPath?: string;
+  templateTag?: string;
+  templateTagReplacement?: string;
+
+  relativePath: string;
+  includeSourceMaps: boolean;
+  includeTemplateTokens: boolean;
+}
+
+interface PreprocessedOutput {
+  output: string;
+  replacements: Replacement[];
+}
+
+interface Replacement {
+  type: 'start' | 'end';
+  index: number;
+  oldLength: number;
+  newLength: number;
+  originalLine: number;
+  originalCol: number;
+}
+
+type GetTemplateLocals = (template: string) => string[];
+
+function getMatchStartAndEnd(match: RegExpMatchArray) {
+  return {
+    start: expect(match.index, 'Expected regular expression match to have an index'),
+    end:
+      expect(match.index, 'Expected regular expression match to have an index') + match[0].length,
+  };
+}
+
+function findImportedName(
+  template: string,
+  importPath: string,
+  importIdentifier: string
+): string | undefined {
+  for (const $import of parseStaticImports(template)) {
+    if ($import.moduleName === importPath) {
+      const match = $import.namedImports.find(({ name }) => name === importIdentifier);
+
+      return match?.alias || match?.name;
+    }
+  }
+
+  return undefined;
+}
+
+function replacementFrom(
+  template: string,
+  index: number,
+  oldLength: number,
+  newLength: number,
+  type: 'start' | 'end'
+): Replacement {
+  const loc = expect(
+    lineColumn(template).fromIndex(index),
+    'BUG: expected to find a line/column based on index'
+  );
+
+  return {
+    type,
+    index,
+    oldLength,
+    newLength,
+    originalCol: loc.col,
+    originalLine: loc.line,
+  };
+}
+
+function loadGetTemplateLocals(path: string, exportPath: string): GetTemplateLocals {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const templateLocals = require(path);
+
+  let getTemplateLocals = templateLocals;
+
+  for (const segment of exportPath.split('.')) {
+    getTemplateLocals = getTemplateLocals[segment];
+  }
+
+  return getTemplateLocals;
+}
+
+function replaceMatch(
+  s: MagicString,
+  match: TemplateMatch,
+  startReplacement: string,
+  endReplacement: string,
+  template: string,
+  getTemplateLocals: GetTemplateLocals,
+  includeTemplateTokens: boolean
+): Replacement[] {
+  const { start: openStart, end: openEnd } = getMatchStartAndEnd(match.start);
+  const { start: closeStart, end: closeEnd } = getMatchStartAndEnd(match.end);
+
+  let options = '';
+
+  if (includeTemplateTokens) {
+    const tokensString = getTemplateLocals(template.slice(openEnd, closeStart))
+      .filter((local: string) => local.match(/^[$A-Z_][0-9A-Z_$]*$/i))
+      .join(',');
+
+    if (tokensString.length > 0) {
+      options = `, { scope() { return {${tokensString}}; } }`;
+    }
+  }
+
+  const newStart = `${startReplacement}\``;
+  const newEnd = `\`${options}${endReplacement}`;
+
+  s.overwrite(openStart, openEnd, newStart);
+  s.overwrite(closeStart, closeEnd, newEnd);
+
+  return [
+    replacementFrom(template, openStart, openEnd - openStart, newStart.length, 'start'),
+    replacementFrom(template, closeStart, closeEnd - closeStart, newEnd.length, 'end'),
+  ];
+}
+
+/**
+ * Preprocesses all embedded templates within a JavaScript or TypeScript file.
+ * This function replaces all embedded templates that match our template syntax
+ * with valid, parseable JS. Optionally, it can also include a source map, and
+ * it can also include all possible values used within the template.
+ *
+ * Input:
+ *
+ *   <template><MyComponent/><template>
+ *
+ * Output:
+ *
+ *   [GLIMMER_TEMPLATE(`<MyComponent/>`, { scope() { return {MyComponent}; } })];
+ *
+ * It can also be used with template literals to provide the in scope values:
+ *
+ * Input:
+ *
+ *   hbs`<MyComponent/>`;
+ *
+ * Output
+ *
+ *   hbs(`<MyComponent/>`, { scope() { return {MyComponent}; } });
+ */
+export default function preprocessEmbeddedTemplates(
+  template: string,
+  {
+    getTemplateLocalsRequirePath,
+    getTemplateLocalsExportPath,
+
+    importPath,
+    importIdentifier,
+    templateTag,
+    templateTagReplacement,
+
+    includeSourceMaps,
+    includeTemplateTokens,
+    relativePath,
+  }: PreprocessOptions
+): PreprocessedOutput {
+  const getTemplateLocals = loadGetTemplateLocals(
+    getTemplateLocalsRequirePath,
+    getTemplateLocalsExportPath
+  );
+
+  if (importPath && importIdentifier) {
+    importIdentifier = findImportedName(template, importPath, importIdentifier);
+
+    if (!importIdentifier) {
+      return {
+        output: template,
+        replacements: [],
+      };
+    }
+  }
+
+  const matches = parseTemplates(template, relativePath, templateTag);
+  const replacements: Replacement[] = [];
+  const s = new MagicString(template);
+
+  for (const match of matches) {
+    if (match.type === 'template-literal' && match.tagName === importIdentifier) {
+      replacements.push(
+        ...replaceMatch(
+          s,
+          match,
+          `${match.tagName}(`,
+          ')',
+          template,
+          getTemplateLocals,
+          includeTemplateTokens
+        )
+      );
+    } else if (match.type === 'template-tag') {
+      replacements.push(
+        ...replaceMatch(
+          s,
+          match,
+          `[${templateTagReplacement}(`,
+          ')]',
+          template,
+          getTemplateLocals,
+          includeTemplateTokens
+        )
+      );
+    }
+  }
+
+  let output = s.toString();
+
+  if (includeSourceMaps) {
+    const { dir, name } = path.parse(relativePath);
+
+    const map = s.generateMap({
+      file: `${dir}/${name}.js`,
+      source: relativePath,
+      includeContent: true,
+      hires: true,
+    });
+
+    output += `\n//# sourceMappingURL=${map.toUrl()}`;
+  }
+
+  return {
+    output,
+    replacements,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "compilerOptions": {
+    // Compilation Configuration
+    "target": "es2015",
+    "module": "commonjs",
+    "inlineSources": true,
+    "inlineSourceMap": true,
+    "declaration": true,
+    "outDir": "dist",
+    "baseUrl": ".",
+    "rootDir": "src",
+
+    // Environment Configuration
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+
+    // Enhance Strictness
+    "noUnusedLocals": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": false,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "allowUnreachableCode": false,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+
+    "newLine": "LF",
+
+    "paths": {
+      "*": ["*", "*/src"]
+    }
+  },
+  "include": [
+    // Because of the circular dependency, we have to avoid specifying globs
+    // that include node_modules.
+    "index.ts",
+    "local-types.d.ts",
+    "src/**/*.ts"
+  ],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,12 +1030,48 @@
   resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.2.0.tgz#a039f542dc14c8e8299c81cd5abba95e2459cfa6"
   integrity sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==
 
+"@glimmer/env@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
+
+"@glimmer/interfaces@0.77.5":
+  version "0.77.5"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.77.5.tgz#74c791ba4712588f2e7b65669d90e8d349eee30a"
+  integrity sha512-ahiZX2EG2w1DrXmIxjzmkRrAeRJS+y35YTXhP82/NSyLiS2g7NTgYbqXpsS+VfvYRZ2+EbeXzY7cTe8mN4OUxg==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/syntax@^0.77.5":
+  version "0.77.5"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.77.5.tgz#b841803dd54ea86de7e8ae8850b3760000033bf2"
+  integrity sha512-FRb1onDsP9P2CnbwTyKF91QYIbRJ0svALG7TnAJlUjQU9E4lWdI5lf7vPRh45A4W1rjcAcIcuiIS6oGrdEkhuQ==
+  dependencies:
+    "@glimmer/interfaces" "0.77.5"
+    "@glimmer/util" "0.77.5"
+    "@handlebars/parser" "~2.0.0"
+    simple-html-tokenizer "^0.5.10"
+
+"@glimmer/util@0.77.5":
+  version "0.77.5"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.77.5.tgz#b4e2909d34eb7db34c63fd9d942e0ffa458d4c90"
+  integrity sha512-Y78NnJClpz7sBks3q+ZNNVfCjy8ALcCQOG5GEIm/P9O3+eXMBsx2ac9Umu4LBZqmeINQ9CtFz10u2BiyxOtSQg==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "0.77.5"
+    "@simple-dom/interface" "^1.4.0"
+
 "@glimmer/vm-babel-plugins@0.77.1":
   version "0.77.1"
   resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.1.tgz#80c8b5476ccff68191bc42ebb29928a9b8d22d69"
   integrity sha512-amkBPV3H/3OhYIeXo03sU1VzqmUl8TUxHhjfVJwRy+vQV22S5saZCiUCyOYUsUkxdEG5sU8qooooBY8VomkkBg==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
+
+"@handlebars/parser@~2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
+  integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==
 
 "@iarna/toml@2.2.5":
   version "2.2.5"
@@ -1385,6 +1421,11 @@
   dependencies:
     "@octokit/openapi-types" "^5.1.0"
 
+"@simple-dom/interface@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
+  integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1536,12 +1577,22 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@^7.0.3":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
 "@types/keyv@*":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
   integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
   dependencies:
     "@types/node" "*"
+
+"@types/line-column@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/line-column/-/line-column-1.0.0.tgz#fa5a59c21e885fef3739a273b43dacf55b63437f"
+  integrity sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w==
 
 "@types/mdast@^3.0.0":
   version "3.0.3"
@@ -1600,6 +1651,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/string.prototype.matchall@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/string.prototype.matchall/-/string.prototype.matchall-4.0.0.tgz#cd00ed3b223d02c8bf978d2866f54fd0e68026cd"
+  integrity sha512-PAspRKHfv4D2TDX4PPHzJ/IxI29ahUyQsTIyFl2/keG+C+mk0Gx3ksYNYRC1AWMmtbbjDeC/LTKOtkEB3ETJOA==
+
 "@types/symlink-or-copy@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#4151a81b4052c80bc2becbae09f3a9ec010a9c7a"
@@ -1620,6 +1676,76 @@
   integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/eslint-plugin@^4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.18.0.tgz#50fbce93211b5b690895d20ebec6fe8db48af1f6"
+  integrity sha512-Lzkc/2+7EoH7+NjIWLS2lVuKKqbEmJhtXe3rmfA8cyiKnZm3IfLf51irnBcmow8Q/AptVV0XBZmBJKuUJTe6cQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.18.0"
+    "@typescript-eslint/scope-manager" "4.18.0"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.18.0.tgz#ed6c955b940334132b17100d2917449b99a91314"
+  integrity sha512-92h723Kblt9JcT2RRY3QS2xefFKar4ZQFVs3GityOKWQYgtajxt/tuXIzL7sVCUlM1hgreiV5gkGYyBpdOwO6A==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.18.0"
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/typescript-estree" "4.18.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.18.0.tgz#a211edb14a69fc5177054bec04c95b185b4dde21"
+  integrity sha512-W3z5S0ZbecwX3PhJEAnq4mnjK5JJXvXUDBYIYGoweCyWyuvAKfGHvzmpUzgB5L4cRBb+cTu9U/ro66dx7dIimA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.18.0"
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/typescript-estree" "4.18.0"
+    debug "^4.1.1"
+
+"@typescript-eslint/scope-manager@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.18.0.tgz#d75b55234c35d2ff6ac945758d6d9e53be84a427"
+  integrity sha512-olX4yN6rvHR2eyFOcb6E4vmhDPsfdMyfQ3qR+oQNkAv8emKKlfxTWUXU5Mqxs2Fwe3Pf1BoPvrwZtwngxDzYzQ==
+  dependencies:
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/visitor-keys" "4.18.0"
+
+"@typescript-eslint/types@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.18.0.tgz#bebe323f81f2a7e2e320fac9415e60856267584a"
+  integrity sha512-/BRociARpj5E+9yQ7cwCF/SNOWwXJ3qhjurMuK2hIFUbr9vTuDeu476Zpu+ptxY2kSxUHDGLLKy+qGq2sOg37A==
+
+"@typescript-eslint/typescript-estree@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.18.0.tgz#756d3e61da8c16ab99185532c44872f4cd5538cb"
+  integrity sha512-wt4xvF6vvJI7epz+rEqxmoNQ4ZADArGQO9gDU+cM0U5fdVv7N+IAuVoVAoZSOZxzGHBfvE3XQMLdy+scsqFfeg==
+  dependencies:
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/visitor-keys" "4.18.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.18.0.tgz#4e6fe2a175ee33418318a029610845a81e2ff7b6"
+  integrity sha512-Q9t90JCvfYaN0OfFUgaLqByOfz8yPeTAdotn/XYNm5q9eHax90gzdb+RJ6E9T5s97Kv/UHWKERTmqA0jTKAEHw==
+  dependencies:
+    "@typescript-eslint/types" "4.18.0"
+    eslint-visitor-keys "^2.0.0"
 
 abab@^2.0.3:
   version "2.0.3"
@@ -2347,6 +2473,14 @@ cacheable-request@^7.0.1:
     normalize-url "^4.1.0"
     responselike "^2.0.0"
 
+call-bind@^1.0.0, call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -2813,7 +2947,7 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.0.tgz#83d6b199db041593ac84d781b5222308ccf4c2c1"
   integrity sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==
 
-define-properties@^1.1.2:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   dependencies:
@@ -3089,6 +3223,37 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.18.0-next.2:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0.tgz#ab80b359eecb7ede4c298000390bc5ac3ec7b5a4"
+  integrity sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    is-callable "^1.2.3"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.2"
+    is-string "^1.0.5"
+    object-inspect "^1.9.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.0"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
 es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
@@ -3191,6 +3356,11 @@ eslint-utils@^2.0.0:
 eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^6.8.0:
   version "6.8.0"
@@ -3722,6 +3892,15 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
 
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
@@ -3824,7 +4003,7 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-globby@11.0.2:
+globby@11.0.2, globby@^11.0.1:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
   integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
@@ -3901,6 +4080,11 @@ har-validator@~5.1.3:
     ajv "^6.5.5"
     har-schema "^2.0.0"
 
+has-bigints@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -3913,6 +4097,11 @@ has-flag@^4.0.0:
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
+has-symbols@^1.0.1, has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -4187,6 +4376,15 @@ inquirer@7.3.3, inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
@@ -4231,9 +4429,26 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
+is-bigint@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.1.tgz#6923051dfcbc764278540b9ce0e6b3213aa5ebc2"
+  integrity sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==
+
+is-boolean-object@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0"
+  integrity sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-callable@^1.1.4, is-callable@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
+  integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
 is-ci@3.0.0:
   version "3.0.0"
@@ -4266,6 +4481,11 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-decimal@^1.0.0:
   version "1.0.4"
@@ -4351,10 +4571,20 @@ is-lambda@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
 
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
 is-npm@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
   integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
+
+is-number-object@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
+  integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -4410,6 +4640,14 @@ is-potential-custom-element-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
 
+is-regex@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
+  integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-symbols "^1.0.1"
+
 is-ssh@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.1.tgz#f349a8cadd24e65298037a522cf7520f2e81a0f3"
@@ -4425,6 +4663,18 @@ is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
+is-string@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
+  integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
+
+is-symbol@^1.0.2, is-symbol@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+  dependencies:
+    has-symbols "^1.0.1"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -4451,7 +4701,7 @@ isarray@0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -5123,6 +5373,14 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+line-column@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
+  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
+  dependencies:
+    isarray "^1.0.0"
+    isobject "^2.0.0"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -5241,6 +5499,13 @@ macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
   integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -5663,7 +5928,12 @@ object-hash@^1.3.1:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-inspect@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
+  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -5683,6 +5953,16 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -5885,6 +6165,11 @@ parse-path@^4.0.0:
   dependencies:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
+
+parse-static-imports@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/parse-static-imports/-/parse-static-imports-1.1.0.tgz#ae2f18f18da1a993080ae406a5219455c0bbad5d"
+  integrity sha512-HlxrZcISCblEV0lzXmAHheH/8qEkKgmqkdxyHTPbSqsTUV8GzqmN1L+SSti+VbNPfbBO3bYLPHDiUs2avbAdbA==
 
 parse-url@^5.0.0:
   version "5.0.1"
@@ -6234,6 +6519,14 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexp.prototype.flags@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -6708,6 +7001,15 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -6723,6 +7025,11 @@ silent-error@^1.0.0, silent-error@^1.1.1:
   integrity sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==
   dependencies:
     debug "^2.2.0"
+
+simple-html-tokenizer@^0.5.10:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz#4c5186083c164ba22a7b477b7687ac056ad6b1d9"
+  integrity sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==
 
 sisteransi@^1.0.0:
   version "1.0.0"
@@ -6843,6 +7150,11 @@ source-map@~0.1.x:
   integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
   dependencies:
     amdefine ">=0.0.4"
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 sourcemap-validator@^1.1.0:
   version "1.1.1"
@@ -6965,6 +7277,35 @@ string-width@^4.1.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^5.2.0"
+
+string.prototype.matchall@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz#608f255e93e072107f5de066f81a2dfb78cf6b29"
+  integrity sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+    has-symbols "^1.0.1"
+    internal-slot "^1.0.3"
+    regexp.prototype.flags "^1.3.1"
+    side-channel "^1.0.4"
+
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -7235,9 +7576,21 @@ tree-sync@^1.2.2:
     quick-temp "^0.1.5"
     walk-sync "^0.3.3"
 
+tslib@^1.8.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tsutils@^3.17.1:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -7286,6 +7639,21 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+
+unbox-primitive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.0.tgz#eeacbc4affa28e9b3d36b5eaeccc50b3251b1d3f"
+  integrity sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.0"
+    has-symbols "^1.0.0"
+    which-boxed-primitive "^1.0.1"
 
 underscore.string@~3.3.4:
   version "3.3.5"
@@ -7565,6 +7933,17 @@ whatwg-url@^8.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^2.0.0"
     webidl-conversions "^5.0.0"
+
+which-boxed-primitive@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Adds a function for preprocessing embedded templates. This function finds embedded templates using a simple RegExp + stack based parser which is very limited overall and designed specifically for this purpose. It replaces the embedded templates with parseable JS, and also pre-parses and walks the templates to find all possible identifiers within them and exposes them externally:

```js
class Foo {
  <template>
    <Bar/>

    {{baz}}
  </template>
}
```

Becomes:

```js
class Foo {
  [GLIMMER_TEMPLATE(`
    <Bar/>

    {{baz}}
  `, { scope: () => ({ Bar, baz }) })];
}
```

The preprocessor does not understand the surrounding JS scope and so does not know if the identifiers it emits actually exist in scope and are valid (it will only emit valid JS identifiers, however). So, if the preprocessed output is going to be used by another tool, such as a linter, it's up to the user to postprocess the results and remove errors pertaining to this generated code.

The result also includes a list of `replacements` which let the user know what was replaced in the original template, useful for fixing linting failure locations and so on. Also, it can include and handle sourcemaps.