### PR TITLE
allow passing getTemplateLocals function directly as an option

### DIFF
--- a/__tests__/preprocess-embedded-templates-tests.js
+++ b/__tests__/preprocess-embedded-templates-tests.js
@@ -13,7 +13,7 @@ const EAGER_TEMPLATE_TAG_CONFIG = {
   relativePath: '/foo/bar.gjs',
   includeSourceMaps: false,
   includeTemplateTokens: true,
-}
+};
 
 const TEMPLATE_TAG_CONFIG = {
   getTemplateLocalsRequirePath,

--- a/__tests__/preprocess-embedded-templates-tests.js
+++ b/__tests__/preprocess-embedded-templates-tests.js
@@ -2,6 +2,18 @@ const { preprocessEmbeddedTemplates } = require('../index');
 const { stripIndent } = require('common-tags');
 
 const getTemplateLocalsRequirePath = require.resolve('@glimmer/syntax');
+const { getTemplateLocals } = require('@glimmer/syntax');
+
+const EAGER_TEMPLATE_TAG_CONFIG = {
+  getTemplateLocals,
+
+  templateTag: 'template',
+  templateTagReplacement: 'GLIMMER_TEMPLATE',
+
+  relativePath: '/foo/bar.gjs',
+  includeSourceMaps: false,
+  includeTemplateTokens: true,
+}
 
 const TEMPLATE_TAG_CONFIG = {
   getTemplateLocalsRequirePath,
@@ -29,6 +41,39 @@ const TEMPLATE_LITERAL_CONFIG = {
 
 describe('htmlbars-inline-precompile: preprocessEmbeddedTemplates', () => {
   describe('template tag', () => {
+    it('works with eager config', () => {
+      let preprocessed = preprocessEmbeddedTemplates(
+        stripIndent`
+          <template>Hello, world!</template>
+        `,
+        EAGER_TEMPLATE_TAG_CONFIG
+      );
+
+      expect(preprocessed).toMatchInlineSnapshot(`
+        Object {
+          "output": "[GLIMMER_TEMPLATE(\`Hello, world!\`)]",
+          "replacements": Array [
+            Object {
+              "index": 0,
+              "newLength": 19,
+              "oldLength": 10,
+              "originalCol": 1,
+              "originalLine": 1,
+              "type": "start",
+            },
+            Object {
+              "index": 23,
+              "newLength": 3,
+              "oldLength": 11,
+              "originalCol": 24,
+              "originalLine": 1,
+              "type": "end",
+            },
+          ],
+        }
+      `);
+    });
+
     it('works with basic templates', () => {
       let preprocessed = preprocessEmbeddedTemplates(
         stripIndent`


### PR DESCRIPTION
I think I need this for adding babel to browser-time compile thing-a-ma-jig, [this existing behavior doesn't work in the browser](https://github.com/NullVoxPopuli/limber/pull/19/files#diff-25fdd9591dfbbc048a44b90aa0a56d8191df522d53d44548075805af267ff9cfR15)