### PR TITLE
bugfix: addedImports k/v pair shape is incorrect

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ module.exports = function (babel) {
           });
 
           if (importSpecifier) {
-            addedImports[exportName] = [importSpecifier.node.local];
+            addedImports[exportName] = { id: importSpecifier.node.local };
           }
         }
 


### PR DESCRIPTION
I don't know how to repro this in the test suite but was yaking on this
line [here](https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile/blob/master/index.js#L286) due to the fact that it tries to lookup an `.id` off of the array.