### PR TITLE
Pass through correct filename as modulename to precompile

### DIFF
--- a/__tests__/template-literal-tests.js
+++ b/__tests__/template-literal-tests.js
@@ -3,6 +3,7 @@
 const babel = require('@babel/core');
 const HTMLBarsInlinePrecompile = require('../index');
 const TransformModules = require('@babel/plugin-transform-modules-amd');
+const { join } = require('path');
 
 const { preprocessEmbeddedTemplates } = HTMLBarsInlinePrecompile;
 
@@ -18,13 +19,15 @@ const TEMPLATE_LITERAL_CONFIG = {
   includeTemplateTokens: true,
 };
 
+const FILENAME = join(process.cwd(), 'foo-bar.js');
+
 describe('htmlbars-inline-precompile: useTemplateLiteralProposalSemantics', function () {
   let precompile, plugins, optionsReceived;
 
   function transform(code) {
     return babel
       .transform(code, {
-        filename: 'foo-bar.js',
+        filename: FILENAME,
         plugins,
       })
       .code.trim();
@@ -238,6 +241,9 @@ describe('htmlbars-inline-precompile: useTemplateLiteralProposalSemantics', func
       isProduction: undefined,
       locals: ['baz', 'foo', 'bar'],
       strictMode: true,
+      meta: {
+        moduleName: FILENAME,
+      },
     });
   });
 
@@ -502,6 +508,9 @@ describe('htmlbars-inline-precompile: useTemplateLiteralProposalSemantics', func
         isProduction: undefined,
         locals: ['Baz', 'foo', 'bar'],
         strictMode: true,
+        meta: {
+          moduleName: FILENAME,
+        },
       });
     });
 

--- a/__tests__/template-tag-tests.js
+++ b/__tests__/template-tag-tests.js
@@ -3,6 +3,7 @@
 const babel = require('@babel/core');
 const HTMLBarsInlinePrecompile = require('../index');
 const TransformModules = require('@babel/plugin-transform-modules-amd');
+const { join } = require('path');
 
 const { preprocessEmbeddedTemplates } = HTMLBarsInlinePrecompile;
 
@@ -18,13 +19,15 @@ const TEMPLATE_TAG_CONFIG = {
   includeTemplateTokens: true,
 };
 
+const FILENAME = join(process.cwd(), 'foo-bar.js');
+
 describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function () {
   let precompile, plugins, optionsReceived;
 
   function transform(code) {
     return babel
       .transform(code, {
-        filename: 'foo-bar.js',
+        filename: FILENAME,
         plugins,
       })
       .code.trim();
@@ -243,6 +246,9 @@ describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function
       isProduction: undefined,
       locals: ['baz', 'foo', 'bar'],
       strictMode: true,
+      meta: {
+        moduleName: FILENAME,
+      },
     });
   });
 
@@ -560,6 +566,9 @@ describe('htmlbars-inline-precompile: useTemplateTagProposalSemantics', function
         isProduction: undefined,
         locals: ['Baz', 'foo', 'bar'],
         strictMode: true,
+        meta: {
+          moduleName: FILENAME,
+        },
       });
     });
 

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -8,6 +8,9 @@ const TransformTemplateLiterals = require('@babel/plugin-transform-template-lite
 const TransformModules = require('@babel/plugin-transform-modules-amd');
 const TransformUnicodeEscapes = require('@babel/plugin-transform-unicode-escapes');
 const { stripIndent } = require('common-tags');
+const { join } = require('path');
+
+const FILENAME = join(process.cwd(), 'foo-bar.js');
 
 describe('htmlbars-inline-precompile', function () {
   let precompile, plugins, optionsReceived;
@@ -15,7 +18,7 @@ describe('htmlbars-inline-precompile', function () {
   function transform(code) {
     return babel
       .transform(code, {
-        filename: 'foo-bar.js',
+        filename: FILENAME,
         plugins,
       })
       .code.trim();
@@ -118,6 +121,9 @@ describe('htmlbars-inline-precompile', function () {
 
     expect(optionsReceived).toEqual({
       contents: source,
+      meta: {
+        moduleName: FILENAME,
+      },
     });
   });
 
@@ -144,6 +150,9 @@ describe('htmlbars-inline-precompile', function () {
     expect(optionsReceived).toEqual({
       contents: source,
       isProduction: true,
+      meta: {
+        moduleName: FILENAME,
+      },
     });
   });
 
@@ -170,6 +179,9 @@ describe('htmlbars-inline-precompile', function () {
     expect(optionsReceived).toEqual({
       contents: source,
       isProduction: true,
+      meta: {
+        moduleName: FILENAME,
+      },
     });
   });
 
@@ -197,6 +209,9 @@ describe('htmlbars-inline-precompile', function () {
       isProduction: true,
       locals: null,
       strictMode: false,
+      meta: {
+        moduleName: FILENAME,
+      },
     });
   });
 
@@ -206,6 +221,9 @@ describe('htmlbars-inline-precompile', function () {
 
     expect(optionsReceived).toEqual({
       contents: source,
+      meta: {
+        moduleName: FILENAME,
+      },
     });
   });
 
@@ -239,6 +257,9 @@ describe('htmlbars-inline-precompile', function () {
       qux: true,
       stringifiedThing: {
         foo: 'baz',
+      },
+      meta: {
+        moduleName: FILENAME,
       },
     });
   });
@@ -312,6 +333,9 @@ describe('htmlbars-inline-precompile', function () {
       isProduction: undefined,
       locals: null,
       strictMode: false,
+      meta: {
+        moduleName: FILENAME,
+      },
     });
   });
 
@@ -861,6 +885,9 @@ describe('htmlbars-inline-precompile', function () {
       expect(optionsReceived).toEqual({
         contents: source,
         locals: ['foo', 'bar'],
+        meta: {
+          moduleName: FILENAME,
+        },
       });
     });
 
@@ -873,6 +900,9 @@ describe('htmlbars-inline-precompile', function () {
       expect(optionsReceived).toEqual({
         contents: source,
         locals: ['foo', 'bar'],
+        meta: {
+          moduleName: FILENAME,
+        },
       });
     });
 
@@ -884,6 +914,9 @@ describe('htmlbars-inline-precompile', function () {
       expect(optionsReceived).toEqual({
         contents: source,
         locals: ['foo', 'bar'],
+        meta: {
+          moduleName: FILENAME,
+        },
       });
     });
 
@@ -895,6 +928,9 @@ describe('htmlbars-inline-precompile', function () {
       expect(optionsReceived).toEqual({
         contents: source,
         locals: ['foo', 'bar'],
+        meta: {
+          moduleName: FILENAME,
+        },
       });
     });
 
@@ -906,6 +942,9 @@ describe('htmlbars-inline-precompile', function () {
       expect(optionsReceived).toEqual({
         contents: source,
         locals: ['foo', 'bar'],
+        meta: {
+          moduleName: FILENAME,
+        },
       });
     });
 
@@ -917,6 +956,9 @@ describe('htmlbars-inline-precompile', function () {
       expect(optionsReceived).toEqual({
         contents: source,
         locals: ['foo', 'bar'],
+        meta: {
+          moduleName: FILENAME,
+        },
       });
     });
 

--- a/index.js
+++ b/index.js
@@ -425,6 +425,9 @@ module.exports = function (babel) {
           isProduction,
           locals,
           strictMode,
+          meta: {
+            moduleName: state.file.opts.filename,
+          },
         }),
         options
       );
@@ -518,6 +521,10 @@ module.exports = function (babel) {
         // options, so we override any existing strict option
         compilerOptions.strictMode = true;
       }
+
+      compilerOptions.meta = {
+        moduleName: state.file.opts.filename,
+      };
 
       replacePath(
         path,


### PR DESCRIPTION
### Why
Passing in moduleName will allow astPlugins to have access to the name of the current file they are processing. This will enable them to provide friendly error messages.

### How
- Pass through `state.file.opts.fileName` to calls to the precompile function