### PR TITLE
Ensure babel.parse does not use top level babel config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,10 @@ module.exports = function (babel) {
       precompileResultString = precompile(template, options);
     }
 
-    let precompileResultAST = babel.parse(`var precompileResult = ${precompileResultString};`);
+    let precompileResultAST = babel.parse(`var precompileResult = ${precompileResultString};`, {
+      babelrc: false,
+      configFile: false,
+    });
 
     let templateExpression = precompileResultAST.program.body[0].declarations[0].init;
 


### PR DESCRIPTION
Without this, using `babel.config.js` (as introduced in ember-cli-babel >= 7.24.0) for babel configuration with certain presets (e.g.  `@babel/preset-typescript`) throws an error.
