### PR TITLE
[WIP] precompileTemplate with scope that has properties with different key and value

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -937,16 +937,6 @@ describe('htmlbars-inline-precompile', function () {
       });
     });
 
-    it('errors if scope contains mismatched keys/values', function () {
-      expect(() => {
-        transform(
-          "import { precompileTemplate } from '@ember/template-compilation';\nvar compiled = precompileTemplate('hello', { scope: { foo: bar } });"
-        );
-      }).toThrow(
-        /Scope objects for `precompileTemplate` may only contain direct references to in-scope values, e.g. { foo } or { foo: foo }/
-      );
-    });
-
     it('errors if scope is not an object', function () {
       expect(() => {
         transform(

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -920,6 +920,23 @@ describe('htmlbars-inline-precompile', function () {
       });
     });
 
+    it('correctly handles scope function (object with different key value)', function () {
+      const source = '<Foo />';
+      transform(
+        `import { precompileTemplate } from '@ember/template-compilation';
+        import Foo$1 from 'foo';
+        var compiled = precompileTemplate('${source}', { 
+          scope() { return { 
+            Foo: Foo$1, 
+          }; 
+        }});`
+      );
+      expect(optionsReceived).toEqual({
+        contents: source,
+        locals: ['Foo'],
+      });
+    });
+
     it('errors if scope contains mismatched keys/values', function () {
       expect(() => {
         transform(


### PR DESCRIPTION
## Background

This PR solves a bug in `precompileTemplate` scope. `precompileTemplate` expects that the scope is a function that returns an object with a few properties where keys and values are equal, as in the following example.

```js
import RootSelect from '../different/select.js';
import Select from '../select.js';

precompileTemplate(`
    <RootSelect/>
    <Select/>
    <button {{on "click" this.toogleClicked}}>
      {{#if this.isClicked}}
        Clicked
      {{else}}
        Not clicked
      {{/if}}
    </button>
  `, {
  strictMode: true,
  scope: () => ({
    RootSelect
    Select,
    on
  });
```

But when the project is built with the rollup, imports can be renamed. For example, `Select` can be renamed to `Select$1`, as shown in the following example.

```js
import Select from '../different/select.js';
import Select$1 from '../select.js';

precompileTemplate(`
    <RootSelect/>
    <Select/>
    <button {{on "click" this.toogleClicked}}>
      {{#if this.isClicked}}
        Clicked
      {{else}}
        Not clicked
      {{/if}}
    </button>
  `, {
  strictMode: true,
  scope: () => ({
    RootSelect: Select
    Select: Select$1,
    on
  });
```

From a javascript point of view, everything is correct, and both examples are equivalent. But the second example will fail with an error.

[I have created a simple example where you can see how an import is renamed by rollup](https://github.com/candunaj/template-precompile-scope) and then there is a [problem](https://github.com/candunaj/template-precompile-scope)

## Solution
When a GJS component is built in V2 addon, there is precompileTemplate function in the file in the dist dir. Imported components used in scope can be renamed by Rollup and then properties have different keys and values as shown below:
```js
import Select from '../different/select.js';
import Select$1 from '../select.js';

precompileTemplate(`
    <RootSelect/>
    <Select/>
    <button {{on "click" this.toogleClicked}}>
      {{#if this.isClicked}}
        Clicked
      {{else}}
        Not clicked
      {{/if}}
    </button>
  `, {
  strictMode: true,
  scope: () => ({
    RootSelect: Select,
    Select: Select$1,
    on
  })
```

When the application is built, the [ember-auto-import loads V2 addons with babel-plugin-hbmlbars-inline-precompile](https://github.com/ef4/ember-auto-import/blob/24b1190d47382eaf4af2e8619ee182f526a2d64f/packages/ember-auto-import/ts/package.ts#L525) and replaces the precompileTemplate with _createTemplateFactory as shown below:

```js
import Select from '../different/select.js';
import Select$1 from '../select.js';

_createTemplateFactory({
      "id":"4QKqJqnE",
      "block":"[[[1,\\"\\\\n    \\"],[8,[32,0],null,null,null],[1,\\"\\\\n    \\"],[8,[32,1],null,null,null],[1,\\"\\\\n    \\"],[11,\\"button\\"],[4,    [32,2],[\\"click\\",[30,0,[\\"toogleClicked\\"]]],null],[12],[1,\\"\\\\n\\"],[41,[30,0,[\\"isClicked\\"]],[[[1,\\"        Clicked\\\\n\\"]],[]],[[[1,\\"        Not clicked\\\\n\\"]],[]]],[1,\\"    \\"],[13],[1,\\"\\\\n  \\"]],[],false,[\\"if\\"]]",
      "moduleName":"(unknown template module)",
      "scope":()=>[RootSelect,Select,on],
      "isStrictMode":true
})
```

The problem is that the scope arrow function returns the original names of the properties. It can be solved by wrapping glimmer wire format in a closure function shown below:

```js
import Select from '../different/select.js';
import Select$1 from '../select.js';

_createTemplateFactory(
    ((RootSelect, Select, on)=>
    ({
      "id":"4QKqJqnE",
      "block":"[...]",
      "moduleName":"(unknown template module)",
      "scope":()=>[RootSelect,Select,on],
      "isStrictMode":true
    }))(Select, Select$1, on)
)
```
